### PR TITLE
Add typed envelope core, wrappers, and adapter support

### DIFF
--- a/.github/workflows/adapters.yml
+++ b/.github/workflows/adapters.yml
@@ -3,8 +3,6 @@ name: Adapter contracts
 on:
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "17 3 * * *"
 
 jobs:
   published-extra:
@@ -67,7 +65,7 @@ jobs:
         run: uv run pytest tests/adapters -m adapters
 
   full-enumeration:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/adapters.yml
+++ b/.github/workflows/adapters.yml
@@ -1,0 +1,80 @@
+name: Adapter contracts
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
+
+jobs:
+  published-extra:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: brax
+            import_name: brax
+          - suite: craftax
+            import_name: craftax
+          - suite: jumanji
+            import_name: jumanji
+          - suite: mujoco-playground
+            import_name: mujoco_playground
+          - suite: navix
+            import_name: navix
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv build --wheel --no-sources
+      - run: uv venv .adapter-venv
+      - name: Install the built wheel and selected extra
+        run: |
+          wheel=$(find dist -name '*.whl' -print -quit)
+          test -n "${wheel}"
+          uv pip install --python .adapter-venv/bin/python "${wheel}[${{ matrix.suite }}]" pytest
+      - run: .adapter-venv/bin/python -c "import envelope; import envelope.adapters"
+      - run: .adapter-venv/bin/python -c "import ${{ matrix.import_name }}"
+      - name: Run adapter tests with the isolated extra
+        run: .adapter-venv/bin/pytest tests/adapters -m adapters
+
+  source-backed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: gymnax
+            import_name: gymnax
+            dependency_group: gymnax-adapter
+          - suite: kinetix
+            import_name: kinetix
+            dependency_group: kinetix-adapter
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv sync --group dev --group ${{ matrix.dependency_group }} --locked
+      - run: uv run python -c "import ${{ matrix.import_name }}"
+      - name: Run adapter tests with the isolated source dependency
+        run: uv run pytest tests/adapters -m adapters
+
+  full-enumeration:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv sync --group dev --group adapters --locked
+      - run: uv run pytest tests/adapters -m adapters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  base:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --group dev --locked
+      - run: uv run ruff check src tests
+      - run: uv run ruff format --check src tests
+      - run: uv run pytest -m "not adapters and not packaging"
+
+  typing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv sync --group dev --group adapters --locked
+      - run: uv run ty check
+
+  minimum-jax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv sync --group dev --locked
+      - run: uv pip install --python .venv/bin/python "jax==0.5.0" "jaxlib==0.5.0"
+      - run: uv run --no-sync pytest -m "not adapters and not packaging"
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv run --with-requirements docs/requirements.txt mkdocs build --strict
+
+  distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - run: uv sync --group dev --locked
+      - run: uv build --no-sources
+      - run: ENVELOPE_DIST_DIR=dist uv run pytest -m packaging
+      - run: uv run --no-project --with dist/*.whl python -c "import envelope, importlib.resources; assert importlib.resources.files('envelope').joinpath('py.typed').is_file()"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,45 +9,60 @@ jobs:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
+      - name: Install uv and Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          test -f uv.lock
-          uv sync --group dev --locked
+        run: uv sync --group dev --locked
 
       - name: Run tests
-        run: uv run pytest -m "not adapters"
+        run: uv run pytest -m "not adapters and not packaging"
 
   build:
-    name: Build distribution
+    name: Build and verify distribution
     needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
 
-      - name: Build package
-        run: uv build
+      - name: Verify tag matches project version
+        run: |
+          VERSION=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          test "${GITHUB_REF_NAME}" = "v${VERSION}"
+
+      - name: Install build verification dependencies
+        run: uv sync --group dev --locked
+
+      - name: Build distribution
+        run: uv build --no-sources
+
+      - name: Inspect distribution contents
+        run: ENVELOPE_DIST_DIR=dist uv run pytest -m packaging
+
+      - name: Smoke-test the built wheel
+        run: uv run --no-project --with dist/*.whl python -c "import envelope, importlib.resources; assert importlib.resources.files('envelope').joinpath('py.typed').is_file()"
 
       - name: Store distribution packages
         uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
+          if-no-files-found: error
 
   publish:
     name: Publish to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,18 @@ cython_debug/
 # Weights and Biases
 wandb/
 
+# Reinforcement-learning outputs
+runs/
+checkpoints/
+*.ckpt
+*.jsonl
+
+# Local interpreter/tool selections
+.python-version
+.claude/
+*.old
+*.aip2.isambard
+
 # ruff
 .ruff_cache/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.14
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ env = envelope.wrappers.ObservationNormalizationWrapper(env)
 
 - **Carry state across episodes** to track running statistics, for example to normalize observations.
 - **Explicit wrapper composition** keeps episode boundaries correct. See the
-  [wrapper ordering guide](https://github.com/keraJLi/envelope/blob/main/docs/api/wrappers.md#wrapper-ordering)
-  for the supported standard and pooled stacks.
+  [wrapper compatibility guide](https://github.com/keraJLi/envelope/blob/main/docs/api/wrappers.md#stack-constraints)
+  for enforced constraints and ordering examples.
 
 ## 🔌 Adapters for existing suites
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ env = envelope.wrappers.ObservationNormalizationWrapper(env)
 ## 💪 Powerful, composable wrappers!
 
 - **Carry state across episodes** to track running statistics, for example to normalize observations.
-- **Composable wrappers** can be stacked in any order. For example, `ObservationNormalizationWrapper` before vs. after `VmapWrapper` gives per-env vs. global normalization.
+- **Explicit wrapper composition** keeps episode boundaries correct. See the
+  [wrapper ordering guide](https://github.com/keraJLi/envelope/blob/main/docs/api/wrappers.md#wrapper-ordering)
+  for the supported standard and pooled stacks.
 
 ## 🔌 Adapters for existing suites
 
@@ -56,13 +58,18 @@ let's you create environments from any of the above!
 - **Adapters suite (requires full adapters dependency group)**:
   - `uv sync --group adapters`
   - `uv run pytest -m adapters`
-  - If any adapter dependency is missing/broken, the run will fail fast with an error telling you what to install.
+  - Tests for suites unavailable in a partial installation are skipped.
 
 ## 🏗️ Installation
 
 ```bash
 pip install jax-envelope
+pip install "jax-envelope[navix]"       # one published adapter
+pip install "jax-envelope[adapters]"    # all published adapters
 ```
+
+Gymnax and Kinetix are temporarily source-backed development adapters rather than
+published extras.
 
 ## 💞 Related projects
 

--- a/docs/api/adapters.md
+++ b/docs/api/adapters.md
@@ -10,9 +10,10 @@ the format `SUITE::ENVIRONMENT`, and can pass arguments to the environment const
 env = create("brax::ant", env_kwargs={"backend": "positional"})
 ```
 
-**Note**: Many suites natively support episode truncation and automatic resetting. When
-instantiating adapters, users are highly discouraged from using these features. Instead,
-they should use the envelope-native wrapper ecosystem. 
+Adapters choose backend settings that leave episode boundaries to Envelope by default.
+Explicit backend options are still passed through. Be careful when enabling native
+time limits, auto-reset, batching, or action repetition. Adapters warn when they can
+recognize such an explicit setting, but do not reject it.
 
 Adapters implement the `HasFromNameInit` protocol, that ensures they can be created via
 a `from_name(cls, env_name: str, env_kwargs=None, **kwargs)` function. This is used by
@@ -20,9 +21,13 @@ a `from_name(cls, env_name: str, env_kwargs=None, **kwargs)` function. This is u
 `navix.make` or `brax.envs.create`), and the `kwargs` are passed to the adapter class on
 creation.
 
-Each adapter may have a `default_episode_length` property that is populated depending on
-the suite and specific environment. If it is not `None`, the `create` function will wrap
-the adapter in a `TruncationWrapper` before returning it.
+With `max_episode_steps="default"`, `create` applies the environment's default time
+limit with a `TruncationWrapper`. `None` adds no outer time limit.
+
+Most adapters expose extra suite data under `info.backend`, for example as
+`info.backend.metrics`. If a suite has no such data at reset, those fields contain zero
+placeholders and `info.backend.valid` is false. Navix retains its established top-level
+extra fields.
 
 ## API Reference (`create`)
 

--- a/docs/api/environments.md
+++ b/docs/api/environments.md
@@ -31,6 +31,16 @@ pytree structures and leaf shapes.**
 This guarantees that you can map `jnp.where` on the `Info` they produce, or emit the
 `Info` as the output of `jax.lax.scan`.
 
+## Stack constraints and backend horizons
+
+`Environment.stack_constraints` is empty by default. Environments that need a wrapper
+placement restriction can declare constraints with `not_inside(...)` or
+`not_containing(...)`; wrapper construction validates the complete stack. See the
+wrapper documentation for examples.
+
+`Environment.default_max_steps` is `None` by default. Adapters use it to expose a
+captured backend horizon to `create`, and ordinary wrappers delegate it unchanged.
+
 ## API Reference
 
 ::: envelope.environment.Environment

--- a/docs/api/spaces.md
+++ b/docs/api/spaces.md
@@ -12,16 +12,26 @@ The `PyTreeSpace`s methods and properties are mapped onto the PyTree of subspace
 treating them as the leaves. For example
 
 ```python
-space = PyTreeSpace({
-  "foo": Discrete([3, 5]),
-  "bar": Continuous(low=-1.0, high=1.0)
-})
-space.shape  # {'foo': (2,), 'bar': ()}
+space = PyTreeSpace({"foo": Discrete([3, 5]), "bar": Continuous(low=-1.0, high=1.0)})
+space.shape  # {'foo': (2,), 'bar': ()}
 space.dtype  # {'foo': dtype('int32'), 'bar': dtype('float32')}
 ```
 
 Spaces can be batched using `BatchedSpace`, which returns a view that prepends a batch
-dimension and vectorizes `sample` and `contains`.
+dimension and vectorizes `sample` and `contains`. `peel_batched` removes all leading
+`BatchedSpace` layers and returns their dimensions; `rebatch` reapplies those
+dimensions.
+
+Spaces assume their constructor arguments are internally consistent. Envelope does not
+check obvious invariants such as matching bound shapes and dtypes, positive
+cardinalities and batch sizes, or matching nested structures. These errors will surface
+naturally when the space is sampled, transformed, or compiled by JAX.
+
+`contains` is a lightweight membership operation, not a schema validator, though it
+might fail if space structures don't match. Give `PyTreeSpace` and `BatchedSpace` values
+the matching tree and batch structure. For correctly structured inputs it returns a
+scalar JAX boolean. Discrete values may use any non-boolean integer dtype, and
+continuous values may use any non-boolean real numeric dtype.
 
 The constraints on the `PyTreeSpace`'s members imply a strict ordering on the
 construction of spaces:
@@ -40,3 +50,7 @@ Discrete / Continuous → PyTreeSpace → BatchedSpace
 ::: envelope.spaces.PyTreeSpace
 
 ::: envelope.spaces.BatchedSpace
+
+::: envelope.spaces.peel_batched
+
+::: envelope.spaces.rebatch

--- a/docs/api/struct.md
+++ b/docs/api/struct.md
@@ -19,6 +19,16 @@ purposes in `envelope`:
   `Container`, and holds observation, reward and terminated/truncated flags. Wrappers
   can add information to this, such as current episode statistics.
 
+`Container` sorts additional field names lexicographically, so insertion order does not
+change the Container node definition. JAX control-flow branches must still emit the same
+field names and value pytrees.
+
+Safe `static_field()` values must be hashable, which rejects arrays and ordinary mutable
+containers. Caller-managed opaque metadata may opt out with `static_field(unsafe=True)`.
+
+If a `FrozenPyTreeNode` subclass defines `__post_init__`, it must call
+`super().__post_init__()` to run static-field validation.
+
 
 ## API Reference
 
@@ -29,3 +39,5 @@ purposes in `envelope`:
 ::: envelope.struct.static_field
 
 ::: envelope.struct.Container
+
+::: envelope.struct.zeros_like

--- a/docs/api/wrappers.md
+++ b/docs/api/wrappers.md
@@ -22,47 +22,94 @@ bootstrapping), and `ObservationNormalizationWrapper` adds `unnormalized_obs`.
 Three wrappers add batch dimensions:
 
 - **`VmapWrapper`** vmaps a single environment with `batch_size` parallel instances.
-- **`VmapEnvsWrapper`** vmaps over a batched pytree of environment instances, for example
-  created via `jax.vmap(make_env)(params)`. This is useful when different instances have
-  different configurations.
-- **`PooledInitVmapWrapper`** vmaps like `VmapWrapper`, but pre-computes a pool of initial
-  states and samples from them on reset. It also includes built-in autoreset logic, making
-  it an alternative to `AutoResetWrapper` + `VmapWrapper`.
+- **`VmapEnvsWrapper`** vmaps over a batched pytree of environment instances, for
+  example created via `jax.vmap(make_env)(params)`. This is useful when different
+  instances have different configurations.
+- **`PooledInitVmapWrapper`** vectorizes like `VmapWrapper`, but lazily generates a
+  small pool of initial states, from which it samples the next state of done
+  environments. An explicit reset still calls the wrapped environment's vectorized
+  reset. It is an alternative to `AutoResetWrapper` + `VmapWrapper` that is
+  computationally efficient.
 
-## Wrapper Ordering
+## Stack constraints
 
-The key constraint is that `AutoResetWrapper` calls `reset()` on its inner wrapper chain
-when an episode ends. Wrappers that need their `reset()` triggered on episode boundaries
-(e.g. `TruncationWrapper` resetting its step counter) must therefore be **inside**
-`AutoResetWrapper`. Vectorization wrappers must be **outside**, since autoreset operates
-per-element.
+Compatibility uses directional, type-based constraints. A wrapper or environment may
+declare:
 
-From innermost to outermost:
-```
-base env → Observation/action transforms → Episode logic → AutoReset → Vectorization
-```
-
-A concrete example with all layers:
-```
-VmapWrapper                              # outermost: adds batch dim
-└─ AutoResetWrapper                      # resets on done, adds `final`
-   └─ StateInjectionWrapper              # (optional) overrides reset target
-      └─ EpisodeStatisticsWrapper        # tracks reward/length
-         └─ TruncationWrapper            # caps episode length
-            └─ ObservationNormalizationWrapper
-               └─ ContinuousObservationWrapper
-                  └─ ClipActionWrapper
-                     └─ base env         # innermost
+```python
+class MyWrapper(Wrapper):
+    stack_constraints = (
+        not_inside(SomeOuterType),
+        not_containing(SomeInnerType),
+    )
 ```
 
-Not all wrappers are needed in every pipeline. The ordering between wrappers in the same
-layer (e.g. the observation/action transforms) is flexible.
+`not_inside(X)` searches the complete outer chain. `not_containing(X)` searches the
+complete inner chain. Matching uses `isinstance`, so subclasses and marker mixins work
+without a separate role registry. The entire stack is validated whenever a wrapper is
+constructed, including constraints declared by a custom base environment.
+
+The built-in hard constraints are:
+
+| Owner | Cannot be inside | Cannot contain |
+| --- | --- | --- |
+| `AutoResetWrapper` | `PooledInitializationWrapper` | `VectorizingWrapper` |
+| `ObservationNormalizationWrapper` | `PooledInitializationWrapper` | — |
+| `StateInjectionWrapper` | `PooledInitializationWrapper` | — |
+| `PooledInitVmapWrapper` | — | `VectorizingWrapper` |
+
+`VmapWrapper` and `VmapEnvsWrapper` implement `VectorizingWrapper`.
+`PooledInitVmapWrapper` implements both `VectorizingWrapper` and
+`PooledInitializationWrapper`. All other built-in wrappers have no hard stack
+constraints. Configurations that are runnable but surprising are left to the user.
+
+Conceptually, each rule points in the direction it searches:
+
+```text
+outer wrappers  ←  not_inside(...)  [owner]  not_containing(...)  →  inner wrappers
+```
+
+For example, autoreset must be vectorized from the outside:
+
+```text
+VmapWrapper
+└─ AutoResetWrapper       valid
+   └─ base
+
+AutoResetWrapper
+└─ VmapWrapper            rejected: AutoResetWrapper cannot contain VmapWrapper
+   └─ base
+```
+
+Observation normalization works on either side of ordinary vectorization. Outside a
+`VmapWrapper` it maintains shared statistics; inside it, each vectorized instance has
+independent statistics. It may wrap pooled initialization but cannot be placed inside
+it. It normalizes terminal observations detected structurally through `info.final` and
+`info.final_valid`, while retaining raw values as `info.final.unnormalized_obs`.
+
+Only top-level observations update the running statistics. A terminal observation is
+normalized with the same current statistics, but is not counted as another sample.
 
 ## API Reference
+
+### Core Wrapper Infrastructure
 
 ::: envelope.wrappers.Wrapper
 
 ::: envelope.wrappers.WrappedState
+
+::: envelope.wrappers.StackConstraint
+
+::: envelope.wrappers.not_inside
+
+::: envelope.wrappers.not_containing
+
+::: envelope.wrappers.VectorizingWrapper
+
+::: envelope.wrappers.PooledInitializationWrapper
+
+
+### Wrapper Instances
 
 ::: envelope.wrappers.AutoResetWrapper
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ plugins:
             show_signature: true
             separate_signature: false
             show_if_no_docstring: false
+            docstring_options:
+              warn_unknown_params: false
             heading_level: 3
             filters:
               - "!^_"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jax-envelope"
-version = "0.4.2"
+version = "0.5.0"
 description = "A JAX-native environment interface with powerful wrappers and adapters for popular RL environment suites"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -41,44 +41,84 @@ Documentation = "https://github.com/keraJLi/envelope#readme"
 Issues = "https://github.com/keraJLi/envelope/issues"
 Changelog = "https://github.com/keraJLi/envelope/releases"
 
+[project.optional-dependencies]
+brax = ["brax>=0.13.0"]
+craftax = ["craftax>=1.6.0"]
+jumanji = ["jumanji>=1.0.1"]
+mujoco-playground = ["playground>=0.1.0"]
+navix = ["navix>=0.7.0"]
+adapters = [
+    "brax>=0.13.0",
+    "craftax>=1.6.0",
+    "jumanji>=1.0.1",
+    "playground>=0.1.0",
+    "navix>=0.7.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/envelope"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/tests",
+    "/docs",
+    "/.github",
+    "/README.md",
+    "/LICENSE",
+    "/pyproject.toml",
+    "/mkdocs.yml",
+    "/.readthedocs.yaml",
+]
+exclude = [
+    "/.gitignore",
+]
 
 [dependency-groups]
 adapters = [
     "brax>=0.13.0",
-    "craftax>=1.4.3",
+    "craftax>=1.6.0",
     "navix>=0.7.0",
     "jumanji>=1.0.1",
     "playground>=0.1.0",
     "gymnax",
     "kinetix-env",
 ]
+gymnax-adapter = ["gymnax"]
+kinetix-adapter = ["kinetix-env"]
 dev = [
     "hypothesis>=6.148.1",
+    "pre-commit>=4.0.0",
+    "ty>=0.0.59",
     "pytest>=9.0.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.14.2",
 ]
-
 [tool.uv]
 override-dependencies = [
     "tensorflow-probability>=0.26.0.dev20260116",
 ]
 
 [tool.uv.sources]
-gymnax = { git = "https://github.com/RobertTLange/gymnax.git" }
-kinetix-env = { git = "https://github.com/FLAIROx/Kinetix.git" }
+gymnax = { git = "https://github.com/RobertTLange/gymnax.git", rev = "18f2e7f3cffafc7042c76fdc538c83957418a9a9" }
+kinetix-env = { git = "https://github.com/FLAIROx/Kinetix.git", rev = "df4de60cabd42dbd1c35fb5214fdc6728710e33d" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [
   "adapters: tests requiring optional adapters dependencies",
+  "packaging: tests that build and inspect distribution artifacts",
 ]
+
+[tool.ty.environment]
+python-version = "3.12"
+
+[tool.ty.src]
+include = ["src/envelope"]
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,19 @@ Changelog = "https://github.com/keraJLi/envelope/releases"
 [project.optional-dependencies]
 brax = ["brax>=0.13.0"]
 craftax = ["craftax>=1.6.0"]
-jumanji = ["jumanji>=1.0.1"]
+jumanji = [
+    "jumanji>=1.0.1",
+    # Jumanji 1.1.1 imports requests for Sokoban but omits it from its metadata.
+    "requests",
+]
 mujoco-playground = ["playground>=0.1.0"]
 navix = ["navix>=0.7.0"]
 adapters = [
     "brax>=0.13.0",
     "craftax>=1.6.0",
     "jumanji>=1.0.1",
+    # Jumanji 1.1.1 imports requests for Sokoban but omits it from its metadata.
+    "requests",
     "playground>=0.1.0",
     "navix>=0.7.0",
 ]
@@ -84,6 +90,8 @@ adapters = [
     "craftax>=1.6.0",
     "navix>=0.7.0",
     "jumanji>=1.0.1",
+    # Jumanji 1.1.1 imports requests for Sokoban but omits it from its metadata.
+    "requests",
     "playground>=0.1.0",
     "gymnax",
     "kinetix-env",

--- a/src/envelope/__init__.py
+++ b/src/envelope/__init__.py
@@ -1,7 +1,8 @@
 from envelope.adapters import create
-from envelope.environment import Environment, Info, InfoContainer
+from envelope.environment import Environment, InfoContainer
 from envelope.spaces import BatchedSpace, Continuous, Discrete, PyTreeSpace, Space
 from envelope.struct import Container, FrozenPyTreeNode, field, static_field
+from envelope.typing import Array, Info, Key, PyTree, State
 from envelope.wrappers import (
     AutoResetWrapper,
     ClipActionWrapper,
@@ -25,6 +26,10 @@ __all__ = [
     "Environment",
     "Info",
     "InfoContainer",
+    "Array",
+    "Key",
+    "PyTree",
+    "State",
     # Spaces
     "Space",
     "BatchedSpace",

--- a/src/envelope/adapters/__init__.py
+++ b/src/envelope/adapters/__init__.py
@@ -1,6 +1,6 @@
 """Compatibility wrappers for various RL environment libraries."""
 
-from typing import Any, Protocol, Self
+from typing import Any, Literal, Protocol
 
 from envelope.environment import Environment
 
@@ -26,7 +26,7 @@ class HasFromNameInit(Protocol):
         env_name: str,
         env_kwargs: dict[str, Any] | None = None,
         **kwargs: dict[str, Any],
-    ) -> Self:
+    ) -> Environment:
         """Creates an environment from a name and keyword arguments. Unless otherwise
         noted, the created environment will have its default parameters, with
         truncation and auto-reset disabled.
@@ -39,13 +39,20 @@ class HasFromNameInit(Protocol):
 
 
 def create(
-    env_name: str, env_kwargs: dict[str, Any] | None = None, **kwargs: dict[str, Any]
+    env_name: str,
+    env_kwargs: dict[str, Any] | None = None,
+    *,
+    max_episode_steps: Literal["default"] | int | None = "default",
+    **kwargs: dict[str, Any],
 ) -> Environment:
     """Create an environment from a prefixed environment ID.
 
     Args:
         env_name: Environment ID in the format "suite::env_name" (e.g., "brax::ant")
         env_kwargs: Keyword arguments passed to the suite's environment constructor
+        max_episode_steps: Episode horizon. When omitted or set to ``"default"``, use
+            the adapter's captured backend default; a positive integer overrides it;
+            ``None`` disables truncation.
         **kwargs: Additional keyword arguments passed to the environment wrapper
 
     Returns:
@@ -85,18 +92,19 @@ def create(
     except ImportError as e:
         raise ImportError(
             f"Failed to import {suite} wrapper. "
-            f"Make sure you have installed the '{suite}' dependencies. "
+            f"Make sure the '{suite}' library is installed. "
             f"Original error: {e}"
         ) from e
 
     env = env_class.from_name(env_name, env_kwargs=env_kwargs, **kwargs)
 
-    # Wrap with TruncationWrapper using adapter's default
-    default_max_steps = getattr(env, "default_max_steps", None)
-    if default_max_steps is not None:
+    if max_episode_steps == "default":
+        max_episode_steps = env.default_max_steps
+
+    if max_episode_steps is not None:
         from envelope.wrappers.truncation_wrapper import TruncationWrapper
 
-        env = TruncationWrapper(env=env, max_steps=int(default_max_steps))
+        env = TruncationWrapper(env=env, max_steps=max_episode_steps)
 
     return env
 

--- a/src/envelope/adapters/_common.py
+++ b/src/envelope/adapters/_common.py
@@ -1,0 +1,108 @@
+"""Shared adapter-internal helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import warnings
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from envelope import spaces
+from envelope.struct import Container, zeros_like
+
+
+def warn_if_wrapper_overlap(
+    adapter_name: str,
+    supplied_args: Mapping[str, Any] | Iterable[str] | None,
+    wrapper_args: Iterable[str],
+    **optional_args: Any,
+) -> None:
+    """Warn if explicitly supplied backend arguments overlap wrapper controls.
+
+    Named optional arguments count as supplied when their value is not ``None``.
+    """
+    supplied_args = set(supplied_args or ())
+    supplied_args.update(
+        name for name, value in optional_args.items() if value is not None
+    )
+    explicit_settings = sorted(supplied_args.intersection(wrapper_args))
+    if not explicit_settings:
+        return
+
+    warnings.warn(
+        f"Explicit {adapter_name} backend settings may overlap with Envelope "
+        f"wrappers: {', '.join(explicit_settings)}.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+
+def backend_container(metadata: Any) -> Container:
+    """Normalize suite metadata to a dot-accessible, JAX-compatible namespace."""
+    if isinstance(metadata, Container):
+        return metadata
+    if dataclasses.is_dataclass(metadata) and not isinstance(metadata, type):
+        values = {
+            item.name: getattr(metadata, item.name)
+            for item in dataclasses.fields(metadata)
+        }
+    elif isinstance(metadata, Mapping):
+        values = dict(metadata)
+    else:
+        values = {"value": metadata}
+
+    if not all(isinstance(key, str) for key in values):
+        return Container().update(value=metadata)
+    return Container().update(**values)
+
+
+def _capture_horizon(value: Any) -> int | None:
+    """Convert a finite backend horizon to an integer."""
+    if value is None or not math.isfinite(value):
+        return None
+    return int(value)
+
+
+def _warn_preserved_horizon(adapter_name: str, parameter_name: str) -> None:
+    warnings.warn(
+        f"Explicit {adapter_name} {parameter_name} is preserved; backend timeouts "
+        "are reported as termination.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+
+def _convert_gymnaxlike_space(
+    backend_space: Any,
+    *,
+    box_type: type[Any],
+    discrete_type: type[Any],
+) -> spaces.Space:
+    """Convert a Gymnax-like Box or Discrete leaf space."""
+    bs = backend_space  # alias for legibility
+    if isinstance(backend_space, box_type):
+        low = jnp.broadcast_to(bs.low, bs.shape).astype(bs.dtype)
+        high = jnp.broadcast_to(bs.high, bs.shape).astype(bs.dtype)
+        return spaces.Continuous(low=low, high=high)
+    if isinstance(bs, discrete_type):
+        n = jnp.broadcast_to(bs.n, bs.shape).astype(bs.dtype)
+        return spaces.Discrete(n=n)
+    raise ValueError(f"Unsupported space type: {type(bs)}")
+
+
+def _probe_gymnaxlike_info_placeholder(
+    env: Any,
+    env_params: Any,
+    step_fn: Any | None = None,
+) -> Container:
+    """Probe a Gymnax-like environment's step-only info schema."""
+    key = jax.random.key(0)
+    _, state = env.reset(key, env_params)
+    action = env.action_space(env_params).sample(key)
+    step_fn = env.step if step_fn is None else step_fn
+    _, _, _, _, raw_backend = step_fn(key, state, action, env_params)
+    return zeros_like(backend_container(raw_backend)).update(valid=jnp.asarray(False))

--- a/src/envelope/adapters/brax_envelope.py
+++ b/src/envelope/adapters/brax_envelope.py
@@ -1,108 +1,102 @@
-import dataclasses
 import warnings
 from copy import copy
 from functools import cached_property
-from typing import Any, override
+from typing import Any, cast, override
 
 from brax.envs import Env as BraxEnv
-from brax.envs import Wrapper as BraxWrapper
 from brax.envs import create as brax_create
 from jax import numpy as jnp
 
 from envelope import spaces
+from envelope.adapters._common import (
+    _capture_horizon,
+    backend_container,
+    warn_if_wrapper_overlap,
+)
 from envelope.environment import Environment, Info, InfoContainer, State
 from envelope.struct import static_field
 from envelope.typing import Key, PyTree
 
 # Default episode_length in brax.envs.create()
 _BRAX_DEFAULT_EPISODE_LENGTH = 1000
+_CONTROLS = ("episode_length", "auto_reset", "batch_size", "action_repeat")
+
+
+def _brax_state_to_info(brax_state: Any) -> InfoContainer:
+    """Convert a brax state to an envelope InfoContainer."""
+    info = InfoContainer(
+        obs=brax_state.obs,
+        reward=brax_state.reward,
+        terminated=jnp.asarray(brax_state.done, dtype=jnp.bool_),
+    )
+    return info.update(backend=backend_container(brax_state))
 
 
 class BraxEnvelope(Environment):
     """
     Wrapper to convert a Brax environment to a envelope environment.
 
-    Note that Brax' `create` function has a default value of `1000` for the episode
-    length. Thus, the `default_max_steps` property is set to `1000` for all Brax envs.
+    Brax' `create` function defaults to an episode length of `1000`. This horizon, or
+    an explicitly supplied override, is retained as `default_max_steps` while the
+    backend time limit is disabled by default.
 
-    Brax uses a dataclass as the environment state, which we return in full as fields of
-    the `Info` object.
+    Brax uses a dataclass as its state. Its fields are preserved under ``info.backend``.
 
     Args:
         brax_env (BraxEnv): the Brax environment.
     """
 
-    brax_env: BraxEnv = static_field()
+    brax_env: BraxEnv = static_field(unsafe=True)
+    _max_steps: int | None = static_field(default=_BRAX_DEFAULT_EPISODE_LENGTH)
 
     @classmethod
     def from_name(
         cls, env_name: str, env_kwargs: dict[str, Any] | None = None
     ) -> "BraxEnvelope":
         """
-        Create a `BraxEnvelope` from a name and keyword arguments.
-        `env_kwargs` arepassed to `brax.envs.create`.
+        Create a `BraxEnvelope` from a name and keyword arguments. `env_kwargs` are
+        passed to `brax.envs.create`.
         """
-        env_kwargs = env_kwargs or {}
-        if "episode_length" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'episode_length' directly. "
-                "Use TruncationWrapper for episode length control."
-            )
-        if "auto_reset" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'auto_reset' directly. "
-                "Use AutoResetWrapper for auto-reset behavior."
-            )
+        warn_if_wrapper_overlap("Brax", env_kwargs, _CONTROLS)
 
-        env_kwargs["episode_length"] = jnp.inf
-        env_kwargs["auto_reset"] = False
-        env = brax_create(env_name, **env_kwargs)
-        return cls(brax_env=env)
+        env_kwargs = env_kwargs or {}
+        default_max_steps = _capture_horizon(
+            env_kwargs.get("episode_length", _BRAX_DEFAULT_EPISODE_LENGTH)
+        )
+        backend_kwargs = {"episode_length": None, "auto_reset": False, **env_kwargs}
+        env = cast(Any, brax_create)(env_name, **backend_kwargs)
+        return cls(brax_env=env, _max_steps=default_max_steps)
 
     @property
-    def default_max_steps(self) -> int:
-        return _BRAX_DEFAULT_EPISODE_LENGTH
-
-    def __post_init__(self):
-        if isinstance(self.brax_env, BraxWrapper):
-            warnings.warn(
-                "Environment wrapping should be handled by envelope. "
-                "Unwrapping brax environment before converting..."
-            )
-            object.__setattr__(self, "brax_env", self.brax_env.unwrapped)
+    def default_max_steps(self) -> int | None:
+        return self._max_steps
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
         brax_state = self.brax_env.reset(key)
-        info = InfoContainer(obs=brax_state.obs, reward=0.0, terminated=False)
-        info = info.update(**dataclasses.asdict(brax_state))
+        info = _brax_state_to_info(brax_state)
         return brax_state, info
 
     @override
     def step(self, state: State, action: PyTree) -> tuple[State, Info]:
         brax_state = self.brax_env.step(state, action)
-        info = InfoContainer(
-            obs=brax_state.obs,
-            reward=brax_state.reward,
-            terminated=jnp.asarray(brax_state.done, dtype=bool),
-        )
-        info = info.update(**dataclasses.asdict(brax_state))
+        info = _brax_state_to_info(brax_state)
         return brax_state, info
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> spaces.Space:
         # All brax environments have action limit of -1 to 1
-        return spaces.Continuous.from_shape(
-            low=-1.0, high=1.0, shape=(self.brax_env.action_size,)
-        )
+        shape = (self.brax_env.action_size,)
+        return spaces.Continuous.from_shape(low=-1.0, high=1.0, shape=shape)
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> spaces.Space:
         # All brax environments have observation limit of -inf to inf
+        obs_size = cast(int, self.brax_env.observation_size)
         return spaces.Continuous.from_shape(
-            low=-jnp.inf, high=jnp.inf, shape=(self.brax_env.observation_size,)
+            low=-jnp.inf, high=jnp.inf, shape=(obs_size,)
         )
 
     def __deepcopy__(self, memo):

--- a/src/envelope/adapters/craftax_envelope.py
+++ b/src/envelope/adapters/craftax_envelope.py
@@ -1,61 +1,74 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, override
+from typing import Any, override
 
 import jax
 import jax.numpy as jnp
+from craftax.craftax.craftax_state import EnvParams as CraftaxModernEnvParams
+from craftax.craftax.envs.craftax_pixels_env import (
+    CraftaxPixelsEnv,
+    CraftaxPixelsEnvNoAutoReset,
+)
+from craftax.craftax.envs.craftax_symbolic_env import (
+    CraftaxSymbolicEnv,
+    CraftaxSymbolicEnvNoAutoReset,
+)
+from craftax.craftax_classic.envs.craftax_pixels_env import (
+    CraftaxClassicPixelsEnv,
+    CraftaxClassicPixelsEnvNoAutoReset,
+)
+from craftax.craftax_classic.envs.craftax_state import (
+    EnvParams as CraftaxClassicEnvParams,
+)
+from craftax.craftax_classic.envs.craftax_symbolic_env import (
+    CraftaxClassicSymbolicEnv,
+    CraftaxClassicSymbolicEnvNoAutoReset,
+)
 from craftax.craftax_env import make_craftax_env_from_name
+from craftax.environment_base import spaces as craftax_spaces
 
 from envelope import spaces as envelope_spaces
-from envelope.adapters.gymnax_envelope import _convert_space as _convert_gymnax_space
+from envelope.adapters._common import (
+    _capture_horizon,
+    _convert_gymnaxlike_space,
+    _probe_gymnaxlike_info_placeholder,
+    _warn_preserved_horizon,
+    backend_container,
+    warn_if_wrapper_overlap,
+)
 from envelope.environment import Environment, Info, InfoContainer, State
-from envelope.struct import Container, static_field
+from envelope.struct import Container, field, static_field
 from envelope.typing import Key, PyTree, TypeAlias
 
-if TYPE_CHECKING:
-    from craftax.craftax.craftax_state import EnvParams as CraftaxEnvParamsOriginal
-    from craftax.craftax.envs.craftax_pixels_env import (
-        CraftaxPixelsEnv,
-        CraftaxPixelsEnvNoAutoReset,
-    )
-    from craftax.craftax.envs.craftax_symbolic_env import (
-        CraftaxSymbolicEnv,
-        CraftaxSymbolicEnvNoAutoReset,
-    )
-    from craftax.craftax_classic.envs.craftax_pixels_env import (
-        CraftaxClassicPixelsEnv,
-        CraftaxClassicPixelsEnvNoAutoReset,
-    )
-    from craftax.craftax_classic.envs.craftax_state import (
-        EnvParams as CraftaxClassicEnvParams,
-    )
-    from craftax.craftax_classic.envs.craftax_symbolic_env import (
-        CraftaxClassicSymbolicEnv,
-        CraftaxClassicSymbolicEnvNoAutoReset,
-    )
+CraftaxEnvParams: TypeAlias = CraftaxModernEnvParams | CraftaxClassicEnvParams
+CraftaxEnv: TypeAlias = (
+    CraftaxPixelsEnv
+    | CraftaxSymbolicEnv
+    | CraftaxClassicPixelsEnv
+    | CraftaxClassicSymbolicEnv
+    | CraftaxPixelsEnvNoAutoReset
+    | CraftaxSymbolicEnvNoAutoReset
+    | CraftaxClassicPixelsEnvNoAutoReset
+    | CraftaxClassicSymbolicEnvNoAutoReset
+)
+_CONTROLS = ("auto_reset",)
 
-    CraftaxEnvParams: TypeAlias = CraftaxEnvParamsOriginal | CraftaxClassicEnvParams
-    CraftaxEnv: TypeAlias = (
-        CraftaxPixelsEnv
-        | CraftaxSymbolicEnv
-        | CraftaxClassicPixelsEnv
-        | CraftaxClassicSymbolicEnv
-        | CraftaxPixelsEnvNoAutoReset
-        | CraftaxSymbolicEnvNoAutoReset
-        | CraftaxClassicPixelsEnvNoAutoReset
-        | CraftaxClassicSymbolicEnvNoAutoReset
+
+def _convert_space(space: craftax_spaces.Space) -> envelope_spaces.Space:
+    return _convert_gymnaxlike_space(
+        space,
+        box_type=craftax_spaces.Box,
+        discrete_type=craftax_spaces.Discrete,
     )
-else:
-    CraftaxEnvParams: TypeAlias = Any
-    CraftaxEnv: TypeAlias = Any
 
 
 class CraftaxEnvelope(Environment):
     """
     Wrapper to convert a Craftax environment to a envelope environment.
 
-    Craftax (mostly) uses the Gymnax interface, so the info object is only created on
-    the first `step`. To keep structural equivalence between the `init` and `step`
-    infos, we create a placeholder filled with `jnp.nan` that is returned on `init`.
+    Craftax (mostly) uses the Gymnax interface, so backend info is only created on the
+    first `step`. Construction probes that schema and stores a type-preserving zero-like
+    placeholder; ``info.backend.valid`` distinguishes reset placeholders from real
+    step metadata.
 
     Args:
         craftax_env (CraftaxEnv): the Craftax environment, with baked-in
@@ -64,8 +77,10 @@ class CraftaxEnvelope(Environment):
             the Craftax environment's `reset` and `step` methods.
     """
 
-    craftax_env: CraftaxEnv = static_field()
-    env_params: PyTree = static_field()  # TODO: remove static marker as soon as craftax merges https://github.com/MichaelTMatthews/Craftax/pull/48
+    craftax_env: CraftaxEnv = static_field(unsafe=True)
+    env_params: PyTree = field()
+    _max_steps: int | None = static_field()
+    _empty_backend_info: Container = field()
 
     @classmethod
     def from_name(
@@ -78,42 +93,30 @@ class CraftaxEnvelope(Environment):
         Create a `CraftaxEnvelope` from a name and keyword arguments.
         `env_kwargs` are passed to `craftax.craftax_env.make_craftax_env_from_name`.
         """
+        warn_if_wrapper_overlap("Craftax", env_kwargs, _CONTROLS)
+
         env_kwargs = env_kwargs or {}
-        if "max_timesteps" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'max_timesteps' directly. "
-                "Use TruncationWrapper for episode length control."
-            )
-        if "auto_reset" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'auto_reset' directly. "
-                "Use AutoResetWrapper for auto-reset behavior."
-            )
+        backend_kwargs = {"auto_reset": False, **env_kwargs}
+        env = make_craftax_env_from_name(env_name, **backend_kwargs)
+        if env_params is None:
+            default_max_steps = _capture_horizon(env.default_params.max_timesteps)
+            env_params = env.default_params.replace(max_timesteps=jnp.inf)
+        else:
+            default_max_steps = _capture_horizon(env_params.max_timesteps)
+            if default_max_steps is not None:
+                _warn_preserved_horizon("Craftax", "env_params.max_timesteps")
 
-        env_kwargs["auto_reset"] = False
-        env = make_craftax_env_from_name(env_name, **env_kwargs)
-        default_params = env.default_params.replace(max_timesteps=jnp.inf)
-
-        env_params = env_params or default_params
-        return cls(craftax_env=env, env_params=env_params)
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(env, env_params)
+        return cls(
+            craftax_env=env,
+            env_params=env_params,
+            _max_steps=default_max_steps,
+            _empty_backend_info=empty_backend_info,
+        )
 
     @property
-    def default_max_steps(self) -> int:
-        return int(self.craftax_env.default_params.max_timesteps)
-
-    @cached_property
-    def _craftax_info_placeholder(self) -> PyTree:
-        # Note that the placeholder that is returned only has nan values where it's
-        # dtype is a subdtype of float. TODO: Should we use empty_like?
-        key = jax.random.key(0)
-        _, state = self.craftax_env.reset(key, self.env_params)
-        _, _, _, _, info = self.craftax_env.step(
-            key,
-            state,
-            self.craftax_env.action_space(self.env_params).sample(key),
-            self.env_params,
-        )
-        return jax.tree.map(lambda x: jnp.full_like(x, jnp.nan), info)
+    def default_max_steps(self) -> int | None:
+        return self._max_steps
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
@@ -121,7 +124,7 @@ class CraftaxEnvelope(Environment):
         obs, env_state = self.craftax_env.reset(subkey, self.env_params)
         state = Container().update(key=key, env_state=env_state)
         info = InfoContainer(obs=obs, reward=0.0, terminated=False)
-        info = info.update(info=self._craftax_info_placeholder)
+        info = info.update(backend=self._empty_backend_info)
         return state, info
 
     @override
@@ -131,18 +134,17 @@ class CraftaxEnvelope(Environment):
             subkey, state.env_state, action, self.env_params
         )
         state = state.update(key=key, env_state=env_state)
+        backend = backend_container(env_info).update(valid=jnp.asarray(True))
         info = InfoContainer(obs=obs, reward=reward, terminated=done)
-        info = info.update(info=env_info)
+        info = info.update(backend=backend)
         return state, info
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> envelope_spaces.Space:
-        return _convert_gymnax_space(self.craftax_env.action_space(self.env_params))
+        return _convert_space(self.craftax_env.action_space(self.env_params))
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> envelope_spaces.Space:
-        return _convert_gymnax_space(
-            self.craftax_env.observation_space(self.env_params)
-        )
+        return _convert_space(self.craftax_env.observation_space(self.env_params))

--- a/src/envelope/adapters/gymnax_envelope.py
+++ b/src/envelope/adapters/gymnax_envelope.py
@@ -73,9 +73,7 @@ class GymnaxEnvelope(Environment):
         else:
             default_max_steps = _capture_horizon(env_params.max_steps_in_episode)
             if default_max_steps is not None:
-                _warn_preserved_horizon(
-                    "Gymnax", "env_params.max_steps_in_episode"
-                )
+                _warn_preserved_horizon("Gymnax", "env_params.max_steps_in_episode")
 
         empty_backend_info = _probe_gymnaxlike_info_placeholder(
             gymnax_env, env_params, step_fn=gymnax_env.step_env

--- a/src/envelope/adapters/gymnax_envelope.py
+++ b/src/envelope/adapters/gymnax_envelope.py
@@ -9,6 +9,13 @@ from gymnax.environments.environment import Environment as GymnaxEnv
 from gymnax.environments.environment import EnvParams as GymnaxEnvParams
 
 from envelope import spaces as envelope_spaces
+from envelope.adapters._common import (
+    _capture_horizon,
+    _convert_gymnaxlike_space,
+    _probe_gymnaxlike_info_placeholder,
+    _warn_preserved_horizon,
+    backend_container,
+)
 from envelope.environment import Environment, Info, InfoContainer, State
 from envelope.struct import Container, field, static_field
 from envelope.typing import Key, PyTree
@@ -27,9 +34,10 @@ class GymnaxEnvelope(Environment):
     """
     Wrapper to convert a Gymnax environment to a envelope environment.
 
-    Gymnax interface only creates the info object on the first `step`. To keep
-    structural equivalence between the `init` and `step` infos, we create a placeholder
-    filled with `jnp.nan` that is returned on `init`.
+    Gymnax only creates backend info on the first `step`. To keep structural
+    equivalence between `init` and `step`, construction probes that schema and stores a
+    type-preserving zero-like placeholder. ``info.backend.valid`` distinguishes the
+    unavailable reset metadata from real step metadata.
 
     Gymnax implements `Tuple` and `Dict` spaces, which are converted to `PyTreeSpace`
     of a `tuple` and `dict` PyTree respectively.
@@ -42,8 +50,10 @@ class GymnaxEnvelope(Environment):
             methods.
     """
 
-    gymnax_env: GymnaxEnv = static_field()
+    gymnax_env: GymnaxEnv = static_field(unsafe=True)
     env_params: PyTree = field()
+    _max_steps: int | None = static_field()
+    _empty_backend_info: Container = field()
 
     @classmethod
     def from_name(
@@ -56,37 +66,30 @@ class GymnaxEnvelope(Environment):
         `env_kwargs` are passed to `gymnax.make`.
         """
         env_kwargs = env_kwargs or {}
-        if "max_steps_in_episode" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'max_steps_in_episode' directly. "
-                "Use TruncationWrapper for episode length control."
-            )
         gymnax_env, default_params = gymnax_create(env_name, **env_kwargs)
-        default_params = default_params.replace(max_steps_in_episode=jnp.inf)
+        if env_params is None:
+            default_max_steps = _capture_horizon(default_params.max_steps_in_episode)
+            env_params = default_params.replace(max_steps_in_episode=jnp.inf)
+        else:
+            default_max_steps = _capture_horizon(env_params.max_steps_in_episode)
+            if default_max_steps is not None:
+                _warn_preserved_horizon(
+                    "Gymnax", "env_params.max_steps_in_episode"
+                )
 
-        env_params = env_params or default_params
-        return cls(gymnax_env=gymnax_env, env_params=env_params)
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(
+            gymnax_env, env_params, step_fn=gymnax_env.step_env
+        )
+        return cls(
+            gymnax_env=gymnax_env,
+            env_params=env_params,
+            _max_steps=default_max_steps,
+            _empty_backend_info=empty_backend_info,
+        )
 
     @property
-    def default_max_steps(self) -> int:
-        return int(self.gymnax_env.default_params.max_steps_in_episode)
-
-    @cached_property
-    def _gymnax_info_placeholder(self) -> PyTree:
-        # Note that the placeholder that is returned only has nan values where it's
-        # dtype is a subdtype of float. TODO: Should we use empty_like?
-        reset_fn = cast(_GymnaxReset, self.gymnax_env.reset)
-        step_fn = cast(_GymnaxStep, self.gymnax_env.step)
-
-        key = jax.random.key(0)
-        _, state = reset_fn(key, self.env_params)
-        _, _, _, _, info = step_fn(
-            key,
-            state,
-            self.gymnax_env.action_space(self.env_params).sample(key),
-            self.env_params,
-        )
-        return jax.tree.map(lambda x: jnp.full_like(x, jnp.nan), info)
+    def default_max_steps(self) -> int | None:
+        return self._max_steps
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
@@ -96,44 +99,46 @@ class GymnaxEnvelope(Environment):
         obs, env_state = reset_fn(subkey, self.env_params)
         state = Container().update(key=key, env_state=env_state)
         info = InfoContainer(obs=obs, reward=0.0, terminated=False)
-        info = info.update(info=self._gymnax_info_placeholder)
+        info = info.update(backend=self._empty_backend_info)
         return state, info
 
     @override
     def step(self, state: State, action: PyTree) -> tuple[State, Info]:
         key, subkey = jax.random.split(state.key)
-        step_fn = cast(_GymnaxStep, self.gymnax_env.step)
+        # Gymnax's public ``step`` auto-resets on completion. Call the raw
+        # transition so Envelope remains the sole owner of reset semantics.
+        step_fn = cast(_GymnaxStep, self.gymnax_env.step_env)
         obs, env_state, reward, done, env_info = step_fn(
             subkey, state.env_state, action, self.env_params
         )
         state = state.update(key=key, env_state=env_state)
+        backend = backend_container(env_info).update(valid=jnp.asarray(True))
         info = InfoContainer(obs=obs, reward=reward, terminated=done)
-        info = info.update(info=env_info)
+        info = info.update(backend=backend)
         return state, info
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> envelope_spaces.Space:
         return _convert_space(self.gymnax_env.action_space(self.env_params))
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> envelope_spaces.Space:
         return _convert_space(self.gymnax_env.observation_space(self.env_params))
 
 
 def _convert_space(gmx_space: gymnax_spaces.Space) -> envelope_spaces.Space:
-    if isinstance(gmx_space, gymnax_spaces.Box):
-        low = jnp.broadcast_to(gmx_space.low, gmx_space.shape).astype(gmx_space.dtype)
-        high = jnp.broadcast_to(gmx_space.high, gmx_space.shape).astype(gmx_space.dtype)
-        return envelope_spaces.Continuous(low=low, high=high)
-    elif isinstance(gmx_space, gymnax_spaces.Discrete):
-        n = jnp.broadcast_to(gmx_space.n, gmx_space.shape).astype(gmx_space.dtype)
-        return envelope_spaces.Discrete(n=n)
-    elif isinstance(gmx_space, gymnax_spaces.Tuple):
+    if isinstance(gmx_space, (gymnax_spaces.Box, gymnax_spaces.Discrete)):
+        return _convert_gymnaxlike_space(
+            gmx_space,
+            box_type=gymnax_spaces.Box,
+            discrete_type=gymnax_spaces.Discrete,
+        )
+    if isinstance(gmx_space, gymnax_spaces.Tuple):
         spaces = tuple(_convert_space(space) for space in gmx_space.spaces)
         return envelope_spaces.PyTreeSpace(spaces)
-    elif isinstance(gmx_space, gymnax_spaces.Dict):
+    if isinstance(gmx_space, gymnax_spaces.Dict):
         spaces = {k: _convert_space(space) for k, space in gmx_space.spaces.items()}
         return envelope_spaces.PyTreeSpace(spaces)
     raise ValueError(f"Unsupported space type: {type(gmx_space)}")

--- a/src/envelope/adapters/jumanji_envelope.py
+++ b/src/envelope/adapters/jumanji_envelope.py
@@ -1,21 +1,26 @@
 import warnings
 from copy import copy
 from functools import cached_property
-from typing import Any, override
+from typing import Any, cast, override
 
 import jax
 import jax.numpy as jnp
-import jumanji
 from jumanji.env import Environment as JumanjiEnv
+from jumanji.registration import make as jumanji_make
 from jumanji.specs import Array, BoundedArray, DiscreteArray, MultiDiscreteArray, Spec
 from jumanji.types import TimeStep as JumanjiTimeStep
 
 from envelope import spaces as envelope_spaces
+from envelope.adapters._common import (
+    _capture_horizon,
+    backend_container,
+    warn_if_wrapper_overlap,
+)
 from envelope.environment import Environment, Info, InfoContainer, State
 from envelope.struct import static_field
 from envelope.typing import Key, PyTree
 
-_MAX_INT = jnp.iinfo(jnp.int32).max
+_MAX_INT = int(jnp.iinfo(jnp.int32).max)
 
 
 class JumanjiEnvelope(Environment):
@@ -30,7 +35,7 @@ class JumanjiEnvelope(Environment):
         jumanji_env (JumanjiEnv): the Jumanji environment.
     """
 
-    jumanji_env: JumanjiEnv = static_field()
+    jumanji_env: JumanjiEnv = static_field(unsafe=True)
     _default_time_limit: int | None = static_field(default=None)
 
     @classmethod
@@ -41,19 +46,16 @@ class JumanjiEnvelope(Environment):
         Create a `JumanjiEnvelope` from a name and keyword arguments.
         `env_kwargs` are passed to `jumanji.make`.
         """
+        warn_if_wrapper_overlap("Jumanji", env_kwargs, ("time_limit",))
+
         env_kwargs = env_kwargs or {}
-        if "time_limit" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'time_limit' directly. "
-                "Use TruncationWrapper for episode length control."
-            )
-
-        # Create env first with defaults to capture default time_limit
-        env = jumanji.make(env_name, **env_kwargs)
-        default_time_limit = getattr(env, "time_limit", None)
-        if default_time_limit is not None:
-            env.time_limit = _MAX_INT
-
+        env = jumanji_make(env_name, **env_kwargs)
+        time_limit = getattr(env, "time_limit", None)
+        if "time_limit" not in env_kwargs and time_limit is not None:
+            cast(Any, env).time_limit = _MAX_INT
+        default_time_limit = (
+            None if time_limit is None else _capture_horizon(time_limit)
+        )
         return cls(jumanji_env=env, _default_time_limit=default_time_limit)
 
     @property
@@ -72,13 +74,13 @@ class JumanjiEnvelope(Environment):
         info = convert_jumanji_to_envelope_info(timestep)
         return env_state, info
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> envelope_spaces.Space:
         return convert_jumanji_spec_to_envelope_space(self.jumanji_env.action_spec)
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> envelope_spaces.Space:
         return convert_jumanji_spec_to_envelope_space(self.jumanji_env.observation_spec)
 
@@ -95,10 +97,28 @@ class JumanjiEnvelope(Environment):
 
 def convert_jumanji_to_envelope_info(timestep: JumanjiTimeStep) -> InfoContainer:
     term = jnp.asarray(timestep.last(), dtype=bool)
+    # Envelope deliberately has no boolean Space. Jumanji action masks are boolean
+    # BoundedArrays, so represent those leaves as int8 to match Discrete(n=2).
+    # All integer-valued Jumanji specs retain their declared dtype unchanged.
+    observation = jax.tree.map(_normalize_observation_leaf, timestep.observation)
     info = InfoContainer(
-        obs=timestep.observation, reward=timestep.reward, terminated=term
-    ).update(**timestep.extras)
+        obs=observation,
+        reward=jnp.asarray(timestep.reward),
+        terminated=term,
+    )
+    info = info.update(backend=backend_container(timestep.extras))
     return info
+
+
+def _normalize_observation_leaf(value: PyTree) -> PyTree:
+    """Represent boolean suite observations as integer-valued discrete samples."""
+    try:
+        array = jnp.asarray(value)
+    except (TypeError, ValueError):
+        return value
+    if jnp.issubdtype(array.dtype, jnp.bool_):
+        return array.astype(jnp.int8)
+    return value
 
 
 def convert_jumanji_spec_to_envelope_space(
@@ -121,6 +141,9 @@ def _spec_to_tree(spec: Spec | PyTree):
         return envelope_spaces.Discrete(n=n)
 
     if isinstance(spec, BoundedArray):
+        dtype = jnp.dtype(spec.dtype)
+        if jnp.issubdtype(dtype, jnp.bool_):
+            return envelope_spaces.Discrete(n=jnp.full(spec.shape, 2, dtype=jnp.int8))
         low = jnp.broadcast_to(jnp.asarray(spec.minimum, dtype=spec.dtype), spec.shape)
         high = jnp.broadcast_to(jnp.asarray(spec.maximum, dtype=spec.dtype), spec.shape)
         return envelope_spaces.Continuous(low=low, high=high)

--- a/src/envelope/adapters/kinetix_envelope.py
+++ b/src/envelope/adapters/kinetix_envelope.py
@@ -5,16 +5,15 @@ API. It mirrors envelope's adapters philosophy:
 - prefer *no* environment-side auto-reset (use `AutoResetWrapper` in envelope)
 - prefer *no* fixed episode time-limits (use `TruncationWrapper` in envelope)
 
-`from_name` supports size categories (`"s"`, `"m"`, `"l"`) that reset to a random
-level from that size on each reset, or `"random"` for fully procedural UED levels.
+`from_name` supports size categories (`"s"`, `"m"`, and `"l"`), procedural
+`"random"` levels, and premade level ids like `s/h4_thrust_aim`.
 """
 
 from __future__ import annotations
 
-import warnings
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Literal, override
+from typing import Any, Callable, Literal, cast, override
 
 import jax
 import jax.numpy as jnp
@@ -30,38 +29,68 @@ from kinetix.util.saving import BASE_DIR, load_from_json_file
 
 from envelope import field
 from envelope import spaces as envelope_spaces
+from envelope.adapters._common import (
+    _capture_horizon,
+    _probe_gymnaxlike_info_placeholder,
+    _warn_preserved_horizon,
+    backend_container,
+    warn_if_wrapper_overlap,
+)
 from envelope.adapters.gymnax_envelope import _convert_space as _convert_gymnax_space
 from envelope.environment import Environment, Info, InfoContainer, State
 from envelope.struct import Container, static_field
 from envelope.typing import Key, PyTree
 
+LevelResetFn = Callable[[Key], Any]
 
-def _warn_auto_reset(auto_reset: bool) -> None:
-    if auto_reset:
-        warnings.warn(
-            "Creating a KinetixEnvelope with auto_reset=True is not recommended, use "
-            "an AutoResetWrapper instead.",
-            stacklevel=2,
-        )
+
+def _warn_if_wrapper_controls(auto_reset: bool) -> None:
+    warn_if_wrapper_overlap(
+        "Kinetix",
+        (),
+        ("auto_reset",),
+        auto_reset=auto_reset or None,
+    )
+
+
+def _without_time_limit(env_params: KinetixEnvEnvParams) -> KinetixEnvEnvParams:
+    return cast(Any, env_params).replace(max_timesteps=jnp.inf)
 
 
 def _list_levels_for_size(size: str) -> list[str]:
-    """Return level path strings (e.g. ``"s/h4_thrust_aim.json"``) for a size category."""
+    """Return packaged level paths for one Kinetix size category."""
     path = Path(BASE_DIR) / size
     return [f"{size}/{file.name}" for file in sorted(path.iterdir())]
+
+
+def _normalize_level_id(level_id: str) -> str:
+    """Normalize a path-like level id.
+
+    Examples:
+        - `"s/h4_thrust_aim"` -> `"s/h4_thrust_aim.json"`
+        - `"/s/h4_thrust_aim.json"` -> `"s/h4_thrust_aim.json"`
+    """
+    level_id = level_id.strip().lstrip("/")
+    if not level_id:
+        raise ValueError("level_id must be a non-empty string")
+    if level_id.endswith("/"):
+        raise ValueError("level_id must not end with '/'")
+    if not level_id.endswith(".json"):
+        level_id = f"{level_id}.json"
+    return level_id
 
 
 class KinetixEnvelope(Environment):
     """Wrapper to convert a Kinetix environment to an envelope environment.
 
     Kinetix environments are constructed via a `reset_fn` that produces a level on each
-    reset, rather than a simple environment name. Two creation modes are provided:
-    `create_from_size` and `create_random`.
+    reset, rather than a simple environment name. Size-category, random, and explicit
+    premade-level creation modes are provided.
 
-    Kinetix only produces the `env_info` dict on the first `step`, not on `reset`. To
-    keep structural equivalence between the `init` and `step` infos (required for
-    `jax.lax.scan`, `jax.vmap`, etc.), a NaN-filled placeholder with the same pytree
-    structure is returned on `init`.
+    Kinetix only produces `env_info` on the first `step`, not on `reset`. Construction
+    probes that schema and stores a type-preserving zero-like placeholder so `init` and
+    `step` remain structurally equivalent. ``info.backend.valid`` distinguishes reset
+    placeholders from real step metadata.
 
     Args:
         kinetix_env (KinetixEnv): the Kinetix environment, with baked-in
@@ -70,33 +99,41 @@ class KinetixEnvelope(Environment):
             to the Kinetix environment's `reset` and `step` methods.
     """
 
-    kinetix_env: KinetixEnv = static_field()
+    kinetix_env: KinetixEnv = static_field(unsafe=True)
     env_params: KinetixEnvEnvParams = field()
+    _max_steps: int | None = static_field()
+    _empty_backend_info: Container = field()
 
     @property
-    def default_max_steps(self) -> int:
-        return int(KinetixEnvEnvParams().max_timesteps)
+    def default_max_steps(self) -> int | None:
+        return self._max_steps
 
     @classmethod
     def from_name(
         cls,
-        env_name: Literal["s", "m", "l", "random"],
+        env_name: str | Literal["s", "m", "l", "random"],
+        env_params: KinetixEnvEnvParams | None = None,
         env_kwargs: dict[str, Any] | None = None,
     ) -> "KinetixEnvelope":
-        """Dispatch to the appropriate creation mode.
-
-        - ``"s"``, ``"m"``, ``"l"``: reset to a random level from that size category
-          via `create_from_size`.
-        - ``"random"``: fully procedural UED levels via `create_random`.
+        """
+        The `from_name` method dispatches between creation modes:
+        - `"s"`, `"m"`, or `"l"`: sample packaged levels of that size.
+        - `"random"`: create a random levels on each reset using Kinetix's
+          `make_reset_fn_sample_kinetix_level` using `self.create_random`.
+        - Any other level id: load a specific packaged JSON level using
+          `self.create_premade`.
         """
         env_kwargs = env_kwargs or {}
         if env_name in ("s", "m", "l"):
-            return cls.create_from_size(env_name, **env_kwargs)
+            return cls.create_from_size(
+                env_name, env_params=env_params, **env_kwargs
+            )
         if env_name == "random":
-            return cls.create_random(**env_kwargs)
-        raise ValueError(
-            f"Invalid env_name {env_name!r}. Expected one of 's', 'm', 'l', 'random'."
-        )
+            return cls.create_random(env_params=env_params, **env_kwargs)
+
+        if env_params is not None:
+            env_kwargs = {**env_kwargs, "env_params": env_params}
+        return cls.create_premade(env_name, **env_kwargs)
 
     @classmethod
     def create_from_size(
@@ -104,22 +141,27 @@ class KinetixEnvelope(Environment):
         size: Literal["s", "m", "l"],
         action_type: ActionType = ActionType.CONTINUOUS,
         observation_type: ObservationType = ObservationType.SYMBOLIC_FLAT,
+        env_params: KinetixEnvEnvParams | None = None,
         auto_reset: bool = False,
     ) -> "KinetixEnvelope":
-        """Reset to a random level from a size category on each reset.
-
-        Loads all packaged levels for the given *size* (``"s"``, ``"m"``, ``"l"``)
-        and builds a reset function that uniformly samples one on each call.
-        """
-        _warn_auto_reset(auto_reset)
-
+        """Reset to a random packaged level from a size category."""
+        _warn_if_wrapper_controls(auto_reset)
         level_paths = _list_levels_for_size(size)
-        # Load one level to obtain static_env_params and env_params.
-        _, static_env_params, env_params = load_from_json_file(level_paths[0])
-        env_params = env_params.replace(max_timesteps=jnp.inf)
+        _, static_env_params, loaded_env_params = load_from_json_file(level_paths[0])
+        default_params = (
+            loaded_env_params
+            if loaded_env_params is not None
+            else KinetixEnvEnvParams()
+        )
+        if env_params is None:
+            default_max_steps = _capture_horizon(default_params.max_timesteps)
+            env_params = _without_time_limit(default_params)
+        else:
+            default_max_steps = _capture_horizon(env_params.max_timesteps)
+            if default_max_steps is not None:
+                _warn_preserved_horizon("Kinetix", "env_params.max_timesteps")
 
         reset_fn = make_reset_fn_list_of_levels(level_paths, static_env_params)
-
         kinetix_env = make_kinetix_env(
             action_type=action_type,
             observation_type=observation_type,
@@ -128,7 +170,73 @@ class KinetixEnvelope(Environment):
             static_env_params=static_env_params,
             auto_reset=auto_reset,
         )
-        return cls(kinetix_env=kinetix_env, env_params=env_params)
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(
+            kinetix_env, env_params
+        )
+        return cls(
+            kinetix_env=kinetix_env,
+            env_params=env_params,
+            _max_steps=default_max_steps,
+            _empty_backend_info=empty_backend_info,
+        )
+
+    @classmethod
+    def create_premade(
+        cls,
+        env_name: str,
+        action_type: ActionType = ActionType.CONTINUOUS,
+        observation_type: ObservationType = ObservationType.SYMBOLIC_FLAT,
+        env_params: KinetixEnvEnvParams | None = None,
+        auto_reset: bool = False,
+    ) -> "KinetixEnvelope":
+        """
+        Load a specific level from a packaged JSON file. The level id has the form
+        `"{size}/{name}"` (e.g. `"s/h4_thrust_aim"`); the `.json` suffix is added
+        automatically.
+        """
+        _warn_if_wrapper_controls(auto_reset)
+
+        # Load level
+        level_id_json = _normalize_level_id(env_name)
+        level, static_env_params, loaded_env_params = load_from_json_file(level_id_json)
+        if level is None:
+            raise ValueError(
+                f"Kinetix premade level {level_id_json!r} did not contain a level state"
+            )
+        default_params = (
+            loaded_env_params
+            if loaded_env_params is not None
+            else KinetixEnvEnvParams()
+        )
+        if env_params is None:
+            default_max_steps = _capture_horizon(default_params.max_timesteps)
+            env_params = _without_time_limit(default_params)
+        else:
+            default_max_steps = _capture_horizon(env_params.max_timesteps)
+            if default_max_steps is not None:
+                _warn_preserved_horizon("Kinetix", "env_params.max_timesteps")
+
+        def reset_fn(_: Key) -> Any:
+            return level
+
+        # Create environments
+        kinetix_env = make_kinetix_env(
+            action_type=action_type,
+            observation_type=observation_type,
+            reset_fn=reset_fn,
+            env_params=env_params,
+            static_env_params=static_env_params,
+            auto_reset=auto_reset,
+        )
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(
+            kinetix_env, env_params
+        )
+        return cls(
+            kinetix_env=kinetix_env,
+            env_params=env_params,
+            _max_steps=default_max_steps,
+            _empty_backend_info=empty_backend_info,
+        )
 
     @classmethod
     def create_random(
@@ -143,10 +251,15 @@ class KinetixEnvelope(Environment):
         Create a random level on each reset using Kinetix's
         `kinetix.environment.ued.ued.make_reset_fn_sample_kinetix_level`.
         """
-        _warn_auto_reset(auto_reset)
+        _warn_if_wrapper_controls(auto_reset)
+        default_params = KinetixEnvEnvParams()
         if env_params is None:
-            env_params = KinetixEnvEnvParams()
-        env_params = env_params.replace(max_timesteps=jnp.inf)
+            default_max_steps = _capture_horizon(default_params.max_timesteps)
+            env_params = _without_time_limit(default_params)
+        else:
+            default_max_steps = _capture_horizon(env_params.max_timesteps)
+            if default_max_steps is not None:
+                _warn_preserved_horizon("Kinetix", "env_params.max_timesteps")
 
         reset_fn = make_reset_fn_sample_kinetix_level(env_params, static_env_params)
         kinetix_env = make_kinetix_env(
@@ -157,19 +270,15 @@ class KinetixEnvelope(Environment):
             static_env_params=static_env_params,
             auto_reset=auto_reset,
         )
-        return cls(kinetix_env=kinetix_env, env_params=env_params)
-
-    @cached_property
-    def _kinetix_info_placeholder(self) -> PyTree:
-        # Note that the placeholder that is returned only has nan values where it's
-        # dtype is a subdtype of float. TODO: Should we use empty_like?
-        key = jax.random.key(0)
-        obs, env_state = self.kinetix_env.reset(key, self.env_params)
-        action = self.action_space.sample(key)
-        _, _, _, _, env_info = self.kinetix_env.step(
-            key, env_state, action, self.env_params
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(
+            kinetix_env, env_params
         )
-        return jax.tree.map(lambda x: jnp.full_like(x, jnp.nan), env_info)
+        return cls(
+            kinetix_env=kinetix_env,
+            env_params=env_params,
+            _max_steps=default_max_steps,
+            _empty_backend_info=empty_backend_info,
+        )
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
@@ -177,7 +286,7 @@ class KinetixEnvelope(Environment):
         obs, env_state = self.kinetix_env.reset(subkey, self.env_params)
         state_out = Container().update(key=key, env_state=env_state)
         info = InfoContainer(obs=obs, reward=0.0, terminated=False)
-        info = info.update(info=self._kinetix_info_placeholder)
+        info = info.update(backend=self._empty_backend_info)
         return state_out, info
 
     @override
@@ -187,17 +296,18 @@ class KinetixEnvelope(Environment):
             subkey, state.env_state, action, self.env_params
         )
         state_out = state.update(key=key, env_state=env_state)
+        backend = backend_container(env_info).update(valid=jnp.asarray(True))
         info = InfoContainer(obs=obs, reward=reward, terminated=done)
-        info = info.update(info=env_info)
+        info = info.update(backend=backend)
         return state_out, info
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> envelope_spaces.Space:
         return _convert_gymnax_space(self.kinetix_env.action_space(self.env_params))
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> envelope_spaces.Space:
         return _convert_gymnax_space(
             self.kinetix_env.observation_space(self.env_params)

--- a/src/envelope/adapters/kinetix_envelope.py
+++ b/src/envelope/adapters/kinetix_envelope.py
@@ -125,9 +125,7 @@ class KinetixEnvelope(Environment):
         """
         env_kwargs = env_kwargs or {}
         if env_name in ("s", "m", "l"):
-            return cls.create_from_size(
-                env_name, env_params=env_params, **env_kwargs
-            )
+            return cls.create_from_size(env_name, env_params=env_params, **env_kwargs)
         if env_name == "random":
             return cls.create_random(env_params=env_params, **env_kwargs)
 
@@ -170,9 +168,7 @@ class KinetixEnvelope(Environment):
             static_env_params=static_env_params,
             auto_reset=auto_reset,
         )
-        empty_backend_info = _probe_gymnaxlike_info_placeholder(
-            kinetix_env, env_params
-        )
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(kinetix_env, env_params)
         return cls(
             kinetix_env=kinetix_env,
             env_params=env_params,
@@ -228,9 +224,7 @@ class KinetixEnvelope(Environment):
             static_env_params=static_env_params,
             auto_reset=auto_reset,
         )
-        empty_backend_info = _probe_gymnaxlike_info_placeholder(
-            kinetix_env, env_params
-        )
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(kinetix_env, env_params)
         return cls(
             kinetix_env=kinetix_env,
             env_params=env_params,
@@ -270,9 +264,7 @@ class KinetixEnvelope(Environment):
             static_env_params=static_env_params,
             auto_reset=auto_reset,
         )
-        empty_backend_info = _probe_gymnaxlike_info_placeholder(
-            kinetix_env, env_params
-        )
+        empty_backend_info = _probe_gymnaxlike_info_placeholder(kinetix_env, env_params)
         return cls(
             kinetix_env=kinetix_env,
             env_params=env_params,

--- a/src/envelope/adapters/mujoco_playground_envelope.py
+++ b/src/envelope/adapters/mujoco_playground_envelope.py
@@ -1,4 +1,3 @@
-import dataclasses
 from functools import cached_property
 from typing import Any, override
 
@@ -6,6 +5,11 @@ from jax import numpy as jnp
 from mujoco_playground import MjxEnv, registry
 
 from envelope import spaces as envelope_spaces
+from envelope.adapters._common import (
+    _capture_horizon,
+    backend_container,
+    warn_if_wrapper_overlap,
+)
 from envelope.environment import Environment, Info, InfoContainer, State
 from envelope.struct import static_field
 from envelope.typing import Key, PyTree
@@ -17,8 +21,8 @@ class MujocoPlaygroundEnvelope(Environment):
     """
     Wrapper to convert a mujoco_playground environment to a envelope environment.
 
-    Mujoco Playground uses a dataclass as the environment state, which we return in full
-    as fields of the `Info` object.
+    Mujoco Playground uses a dataclass as its state. Its fields are preserved under
+    ``info.backend``.
 
     All Mujoco Playground environments have continuous actions and observations, which
     range between `(-1, 1)` and `(-inf, inf)` respectively.
@@ -27,7 +31,7 @@ class MujocoPlaygroundEnvelope(Environment):
         mujoco_playground_env (MjxEnv): the Mujoco Playground environment.
     """
 
-    mujoco_playground_env: MjxEnv = static_field()
+    mujoco_playground_env: MjxEnv = static_field(unsafe=True)
     _default_max_steps: int | None = static_field(default=None)
 
     @classmethod
@@ -41,55 +45,55 @@ class MujocoPlaygroundEnvelope(Environment):
         `env_kwargs` are passed to `config_overrides` of
         `mujoco_playground.registry.load`.
         """
+        warn_if_wrapper_overlap("MuJoCo Playground", env_kwargs, ("episode_length",))
+
         env_kwargs = env_kwargs or {}
-        if "episode_length" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'episode_length' directly. "
-                "Use TruncationWrapper for episode length control."
-            )
-
-        # Get default episode_length from registry config
         default_config = registry.get_default_config(env_name)
-        default_max_steps = default_config.episode_length
+        default_max_steps = _capture_horizon(
+            env_kwargs.get("episode_length", default_config.episode_length)
+        )
 
-        # Set episode_length to a very large value
-        # (mujoco_playground uses int for episode_length, so we use max int instead of inf)
-        env_kwargs["episode_length"] = _MAX_INT
-
-        # Pass all env_kwargs as config_overrides
-        config_overrides = env_kwargs if env_kwargs else None
+        # MuJoCo Playground requires an integer episode length.
+        config_overrides = {"episode_length": _MAX_INT, **env_kwargs}
         env = registry.load(env_name, config_overrides=config_overrides)
         return cls(mujoco_playground_env=env, _default_max_steps=default_max_steps)
 
     @property
-    def default_max_steps(self) -> int:
+    def default_max_steps(self) -> int | None:
         return self._default_max_steps
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
         state = self.mujoco_playground_env.reset(key)
-        info = InfoContainer(obs=state.obs, reward=0.0, terminated=False)
-        info = info.update(metrics=state.metrics, info=state.info)
+        info = InfoContainer(
+            obs=state.obs,
+            reward=state.reward,
+            terminated=jnp.asarray(state.done, dtype=bool),
+        )
+        info = info.update(backend=backend_container(state))
         return state, info
 
     @override
     def step(self, state: State, action: PyTree) -> tuple[State, Info]:
         state = self.mujoco_playground_env.step(state, action)
-        term = jnp.asarray(state.done, dtype=bool)
-        info = InfoContainer(obs=state.obs, reward=state.reward, terminated=term)
-        info = info.update(metrics=state.metrics, info=state.info)
+        info = InfoContainer(
+            obs=state.obs,
+            reward=state.reward,
+            terminated=jnp.asarray(state.done, dtype=bool),
+        )
+        info = info.update(backend=backend_container(state))
         return state, info
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> envelope_spaces.Space:
         # MuJoCo Playground actions are typically bounded [-1, 1]
         return envelope_spaces.Continuous.from_shape(
             low=-1.0, high=1.0, shape=(self.mujoco_playground_env.action_size,)
         )
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> envelope_spaces.Space:
         import jax
 

--- a/src/envelope/adapters/mujoco_playground_envelope.py
+++ b/src/envelope/adapters/mujoco_playground_envelope.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import cached_property
 from typing import Any, override
 
@@ -15,6 +16,18 @@ from envelope.struct import static_field
 from envelope.typing import Key, PyTree
 
 _MAX_INT = int(jnp.iinfo(jnp.int32).max)
+
+
+def _warp_cuda_available() -> bool:
+    """Return whether NVIDIA Warp can execute on a CUDA device."""
+    try:
+        import warp
+    except ImportError:
+        return False
+    try:
+        return bool(warp.is_cuda_available())
+    except (OSError, RuntimeError):
+        return False
 
 
 class MujocoPlaygroundEnvelope(Environment):
@@ -44,6 +57,9 @@ class MujocoPlaygroundEnvelope(Environment):
         Create a `MujocoPlaygroundEnvelope` from a name and keyword arguments.
         `env_kwargs` are passed to `config_overrides` of
         `mujoco_playground.registry.load`.
+
+        If MuJoCo Playground defaults to Warp but CUDA is unavailable, Envelope
+        warns and falls back to JAX. An explicit ``impl`` setting is always preserved.
         """
         warn_if_wrapper_overlap("MuJoCo Playground", env_kwargs, ("episode_length",))
 
@@ -55,6 +71,20 @@ class MujocoPlaygroundEnvelope(Environment):
 
         # MuJoCo Playground requires an integer episode length.
         config_overrides = {"episode_length": _MAX_INT, **env_kwargs}
+        if (
+            env_kwargs.get("impl") is None
+            and getattr(default_config, "impl", None) == "warp"
+            and not _warp_cuda_available()
+        ):
+            warnings.warn(
+                "MuJoCo Playground defaults to Warp, but Warp cannot use a CUDA "
+                "device on this host; falling back to the JAX implementation. Pass "
+                "env_kwargs={'impl': 'warp'} to require Warp explicitly.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            config_overrides["impl"] = "jax"
+
         env = registry.load(env_name, config_overrides=config_overrides)
         return cls(mujoco_playground_env=env, _default_max_steps=default_max_steps)
 

--- a/src/envelope/adapters/navix_envelope.py
+++ b/src/envelope/adapters/navix_envelope.py
@@ -5,27 +5,33 @@ from typing import Any, override
 import jax.numpy as jnp
 import navix
 from navix import spaces as navix_spaces
+from navix.entities import EntityIds
 from navix.environments.environment import Environment as NavixEnv
 
 from envelope import spaces as envelope_spaces
+from envelope.adapters._common import _capture_horizon, warn_if_wrapper_overlap
 from envelope.environment import Environment, Info, InfoContainer, State
+from envelope.struct import static_field
 from envelope.typing import Key, PyTree
 
 _NAVIX_DEFAULT_MAX_STEPS = 100
+_ENTITY_ID_CARDINALITY = (
+    max(int(value) for name, value in vars(EntityIds).items() if name.isupper()) + 1
+)
 
 
 class NavixEnvelope(Environment):
     """
     Wrapper to convert a Navix environment to a envelope environment.
 
-    Navix uses a dataclass as the environment state, which we return in full as fields of
-    the `Info` object.
+    Navix uses a dataclass timestep, which is preserved under ``info.backend``.
 
     Args:
         navix_env (NavixEnv): the Navix environment.
     """
 
-    navix_env: NavixEnv
+    navix_env: NavixEnv = static_field(unsafe=True)
+    _max_steps: int | None = static_field(default=None)
 
     @classmethod
     def from_name(
@@ -35,19 +41,21 @@ class NavixEnvelope(Environment):
         Create a `NavixEnvelope` from a name and keyword arguments.
         `env_kwargs` are passed to `navix.make`.
         """
+        warn_if_wrapper_overlap("Navix", env_kwargs, ("max_steps",))
+
         env_kwargs = env_kwargs or {}
-        if "max_steps" in env_kwargs:
-            raise ValueError(
-                "Cannot override 'max_steps' directly. "
-                "Use TruncationWrapper for episode length control."
-            )
-        env_kwargs["max_steps"] = jnp.inf
-        navix_env = navix.make(env_name, **env_kwargs)
-        return cls(navix_env=navix_env)
+        default_max_steps = _capture_horizon(
+            env_kwargs.get("max_steps", _NAVIX_DEFAULT_MAX_STEPS)
+        )
+        backend_kwargs: dict[str, Any] = {"max_steps": jnp.inf, **env_kwargs}
+        navix_env = navix.make(env_name, **backend_kwargs)
+        return cls(navix_env=navix_env, _max_steps=default_max_steps)
 
     @property
-    def default_max_steps(self) -> int:
-        return _NAVIX_DEFAULT_MAX_STEPS
+    def default_max_steps(self) -> int | None:
+        if self._max_steps is not None:
+            return self._max_steps
+        return _capture_horizon(self.navix_env.max_steps)
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
@@ -59,18 +67,26 @@ class NavixEnvelope(Environment):
         timestep = self.navix_env.step(state, action)
         return timestep, convert_navix_to_envelope_info(timestep)
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> envelope_spaces.Space:
         return convert_navix_to_envelope_space(self.navix_env.action_space)
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> envelope_spaces.Space:
         nvx_obs_space = self.navix_env.observation_space
         obs_space = convert_navix_to_envelope_space(nvx_obs_space)
-        n = obs_space.n
-        n = jnp.maximum(n, 10)  # See https://github.com/epignatelli/navix/issues/109
+        if not isinstance(obs_space, envelope_spaces.Discrete):
+            return obs_space
+        n = jnp.asarray(obs_space.n)
+        # Navix's first symbolic channel contains authoritative EntityIds, while its
+        # declared cardinality currently omits newer ids such as PLAYER. Adjust only
+        # that channel; colour/direction channels retain their backend declarations.
+        # See https://github.com/epignatelli/navix/issues/109.
+        if n.ndim > 0:
+            entity_n = jnp.maximum(n[..., 0], _ENTITY_ID_CARDINALITY)
+            n = n.at[..., 0].set(entity_n)
         return obs_space.replace(n=n)
 
 
@@ -95,8 +111,9 @@ def convert_navix_to_envelope_space(
         return envelope_spaces.Discrete.from_shape(n, shape=nvx_space.shape)
 
     elif isinstance(nvx_space, navix_spaces.Continuous):
-        low = jnp.asarray(nvx_space.minimum).astype(nvx_space.dtype)
-        high = jnp.asarray(nvx_space.maximum).astype(nvx_space.dtype)
-        return envelope_spaces.Continuous.from_shape(low, high, shape=nvx_space.shape)
+        shape, dtype = nvx_space.shape, nvx_space.dtype
+        low = jnp.broadcast_to(nvx_space.minimum, shape).astype(dtype)
+        high = jnp.broadcast_to(nvx_space.maximum, shape).astype(dtype)
+        return envelope_spaces.Continuous(low=low, high=high)
 
     raise ValueError(f"Unsupported space type: {type(nvx_space)}")

--- a/src/envelope/environment.py
+++ b/src/envelope/environment.py
@@ -1,12 +1,36 @@
 from abc import ABC, abstractmethod
 from dataclasses import field
 from functools import cached_property
+from typing import Any, ClassVar, Literal, NamedTuple
 
 from envelope import spaces
 from envelope.struct import Container, FrozenPyTreeNode
 from envelope.typing import Array, Info, Key, PyTree, State
 
-__all__ = ["Environment", "InfoContainer"]
+__all__ = [
+    "Environment",
+    "InfoContainer",
+    "StackConstraint",
+    "not_containing",
+    "not_inside",
+]
+
+
+class StackConstraint(NamedTuple):
+    """A directional prohibition against matching environment or wrapper types."""
+
+    direction: Literal["outer", "inner"]
+    environment_types: tuple[type[Any], ...]
+
+
+def not_inside(*environment_types: type[Any]) -> StackConstraint:
+    """Reject this environment when a matching type appears outside it."""
+    return StackConstraint("outer", environment_types)
+
+
+def not_containing(*environment_types: type[Any]) -> StackConstraint:
+    """Reject this environment when a matching type appears inside it."""
+    return StackConstraint("inner", environment_types)
 
 
 class InfoContainer(Container):
@@ -23,8 +47,8 @@ class InfoContainer(Container):
 
     obs: PyTree
     reward: float | Array
-    terminated: bool
-    truncated: bool = field(default=False)
+    terminated: bool | Array
+    truncated: bool | Array = field(default=False)
 
 
 class Environment(ABC, FrozenPyTreeNode):
@@ -35,6 +59,8 @@ class Environment(ABC, FrozenPyTreeNode):
     environments should expose their wrapped env state as `inner_state` while
     adding any wrapper-specific fields.
     """
+
+    stack_constraints: ClassVar[tuple[StackConstraint, ...]] = ()
 
     @abstractmethod
     def init(self, key: Key) -> tuple[State, Info]:
@@ -78,3 +104,8 @@ class Environment(ABC, FrozenPyTreeNode):
     @property
     def unwrapped(self) -> "Environment":
         return self
+
+    @property
+    def default_max_steps(self) -> int | None:
+        """The backend's captured default horizon, if it has one."""
+        return None

--- a/src/envelope/spaces.py
+++ b/src/envelope/spaces.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from functools import cached_property
 from typing import override
 
 import jax
@@ -10,7 +9,12 @@ from envelope.typing import Key, PyTree
 
 
 class Space(ABC, FrozenPyTreeNode):
-    """Base class for all spaces. Spaces are immutable and hashable."""
+    """Base class for immutable JAX-compatible spaces.
+
+    Space constructors assume their arguments are internally consistent. In
+    particular, callers are responsible for valid bounds and cardinalities, matching
+    shapes and dtypes, positive batch sizes, and matching PyTree structures.
+    """
 
     @property
     @abstractmethod
@@ -27,7 +31,7 @@ class Space(ABC, FrozenPyTreeNode):
         """Sample a random element from the space."""
 
     @abstractmethod
-    def contains(self, x: PyTree) -> bool:
+    def contains(self, x: PyTree) -> jax.Array:
         """Check if `self` contains a sample `x`."""
 
 
@@ -43,7 +47,7 @@ class Discrete(Space):
     n: int | jax.Array
 
     @classmethod
-    def from_shape(cls, n: int, shape: tuple[int, ...]) -> "Discrete":
+    def from_shape(cls, n: int | jax.Array, shape: tuple[int, ...]) -> "Discrete":
         """
         Create a Discrete space from a shape and a number of elements. This is
         a shorthand for `Discrete` with `n` being expanded to the shape.
@@ -61,18 +65,28 @@ class Discrete(Space):
     def sample(self, key: Key) -> jax.Array:
         return jax.random.randint(key, self.shape, 0, self.n, dtype=self.dtype)
 
-    def contains(self, x: int | jax.Array) -> bool:
-        return jnp.all(x >= 0) & jnp.all(x < self.n)
+    def contains(self, x: int | jax.Array) -> jax.Array:
+        try:
+            candidate = jnp.asarray(x)
+        except (TypeError, ValueError):
+            return jnp.asarray(False)
+
+        if candidate.shape != self.shape:
+            return jnp.asarray(False)
+        if not jnp.issubdtype(candidate.dtype, jnp.integer):
+            return jnp.asarray(False)
+        return jnp.all(candidate >= 0) & jnp.all(candidate < self.n)
 
     def __repr__(self) -> str:
         return f"Discrete(shape={self.shape}, dtype={self.dtype}, n={self.n})"
 
 
 class Continuous(Space):
-    """
-    A continuous space with a given lower and upper bound. `low` and `high` can be
-    scalars or arrays. The shape and dtype of the space are inferred from `low` and
-    `high`.
+    """A continuous space with elementwise lower and upper bounds.
+
+    ``low`` and ``high`` can be scalars or arrays. Their shared shape and dtype define
+    the space. Sampling treats each element independently, so a single space may mix
+    finite, one-sided, and unbounded dimensions.
 
     Args:
         low (float | jax.Array): The lower bound of the space.
@@ -111,12 +125,69 @@ class Continuous(Space):
 
     @override
     def sample(self, key: Key) -> jax.Array:
-        uniform_sample = jax.random.uniform(key, self.shape, self.dtype)
-        return self.low + uniform_sample * (self.high - self.low)
+        """Sample independently from every dimension of the space.
+
+        The distribution for each element depends on its bounds:
+
+        - Two finite bounds use a uniform distribution over the interval.
+        - A finite lower bound uses that bound plus a unit exponential sample.
+        - A finite upper bound uses that bound minus a unit exponential sample.
+        - Two infinite bounds use a standard normal distribution.
+
+        One-sided and unbounded samples are clipped to the finite range representable
+        by the space's dtype.
+
+        Args:
+            key: JAX pseudorandom key.
+
+        Returns:
+            An array with the space's shape and dtype.
+        """
+        uniform_key, normal_key, exponential_key = jax.random.split(key, 3)
+        low = jnp.asarray(self.low)
+        high = jnp.asarray(self.high)
+        finite_low = jnp.isfinite(low)
+        finite_high = jnp.isfinite(high)
+
+        uniform = jax.random.uniform(uniform_key, self.shape, self.dtype)
+        normal = jax.random.normal(normal_key, self.shape, self.dtype)
+        exponential = jax.random.exponential(exponential_key, self.shape, self.dtype)
+
+        # A convex combination avoids overflow for wide but finite intervals.
+        bounded = (1 - uniform) * low + uniform * high
+        dtype_info = jnp.finfo(self.dtype)
+        lower_bounded = jnp.minimum(low + exponential, dtype_info.max)
+        upper_bounded = jnp.maximum(high - exponential, dtype_info.min)
+        unbounded = jnp.clip(normal, dtype_info.min, dtype_info.max)
+
+        return jnp.where(
+            finite_low & finite_high,
+            bounded,
+            jnp.where(
+                finite_low,
+                lower_bounded,
+                jnp.where(finite_high, upper_bounded, unbounded),
+            ),
+        )
 
     @override
-    def contains(self, x: jax.Array) -> bool:
-        return jnp.all((x >= jnp.asarray(self.low)) & (x <= jnp.asarray(self.high)))
+    def contains(self, x: jax.Array) -> jax.Array:
+        try:
+            candidate = jnp.asarray(x)
+        except (TypeError, ValueError):
+            return jnp.asarray(False)
+
+        if candidate.shape != self.shape:
+            return jnp.asarray(False)
+
+        is_integer = jnp.issubdtype(candidate.dtype, jnp.integer)
+        is_floating = jnp.issubdtype(candidate.dtype, jnp.floating)
+        if not (is_integer or is_floating):
+            return jnp.asarray(False)
+
+        return jnp.all(
+            (candidate >= jnp.asarray(self.low)) & (candidate <= jnp.asarray(self.high))
+        )
 
     def __repr__(self) -> str:
         dtype_str = getattr(self.dtype, "__name__", str(self.dtype))
@@ -148,6 +219,7 @@ class PyTreeSpace(Space):
                     f"PyTreeSpace leaves must be Discrete or Continuous,"
                     f"got {type(leaf).__name__}"
                 )
+        super().__post_init__()
 
     @override
     def sample(self, key: Key) -> PyTree:
@@ -159,8 +231,7 @@ class PyTreeSpace(Space):
         return jax.tree.unflatten(treedef, samples)
 
     @override
-    def contains(self, x: PyTree) -> bool:
-        # Use tree.map to check containment for each space-value pair
+    def contains(self, x: PyTree) -> jax.Array:
         contains = jax.tree.map(
             lambda space, xi: space.contains(xi),
             self.tree,
@@ -201,6 +272,13 @@ def peel_batched(space: Space) -> tuple[tuple[int, ...], Space]:
     return tuple(dims), s
 
 
+def rebatch(space: Space, batch_dims: tuple[int, ...]) -> Space:
+    """Reapply batch dimensions returned by ``peel_batched``."""
+    for batch_dim in reversed(batch_dims):
+        space = BatchedSpace(space=space, batch_size=batch_dim)
+    return space
+
+
 class BatchedSpace(Space):
     """
     A view that adds a leading batch dimension to a base `Space` without
@@ -236,7 +314,7 @@ class BatchedSpace(Space):
         return jax.vmap(self.space.sample)(keys)
 
     @override
-    def contains(self, x: PyTree) -> bool:
+    def contains(self, x: PyTree) -> jax.Array:
         """
         `BatchedSpace.contains` checks if each entry of `x` along the leading dimension
         is contained in the base (unbatched) `Space`.
@@ -244,11 +322,11 @@ class BatchedSpace(Space):
         result = jax.vmap(self.space.contains)(x)
         return jnp.all(jnp.asarray(result))
 
+    @property
     @override
-    @cached_property
-    def shape(self) -> tuple[int, ...] | PyTree:
+    def shape(self) -> PyTree:
         """
-        The shape of the `BatchedSpace` is the leading batch dimension prepend the
+        The shape of the `BatchedSpace` is the leading batch dimension prepended to the
         shape of the wrapped `Space`. If the wrapped `Space` is a `PyTreeSpace`, the
         shape is a PyTree of the same structure, with the leading batch dimension
         prepended to the shape of each leaf `Space`.
@@ -262,10 +340,9 @@ class BatchedSpace(Space):
             )
         return batch_dims + base.shape
 
-    @override
     @property
-    def dtype(self) -> jnp.dtype | PyTree:
-        """The dtype of the base space (batch dimensions don't affect dtype)."""
+    @override
+    def dtype(self) -> PyTree:
         _, base = peel_batched(self)
         return base.dtype
 

--- a/src/envelope/struct.py
+++ b/src/envelope/struct.py
@@ -263,7 +263,7 @@ class Container:
         core_keys = tuple(f.name for f in core_fields)
         core_vals = tuple(getattr(self, name) for name in core_keys)
 
-        extras_keys = tuple(self._extras)
+        extras_keys = tuple(sorted(self._extras))
         extras_vals = tuple(self._extras[k] for k in extras_keys)
 
         children = core_vals + extras_vals

--- a/src/envelope/struct.py
+++ b/src/envelope/struct.py
@@ -1,15 +1,71 @@
 import dataclasses
 from dataclasses import KW_ONLY
-from typing import Any, Iterable, Iterator, Mapping, Self, Tuple, dataclass_transform
+from typing import (
+    Any,
+    ClassVar,
+    Iterable,
+    Iterator,
+    Mapping,
+    Self,
+    Tuple,
+    dataclass_transform,
+)
 
 import jax
+import jax.numpy as jnp
+from jax.tree_util import GetAttrKey
 
 from envelope.typing import PyTree
 
-__all__ = ["FrozenPyTreeNode", "field", "static_field", "Container"]
+__all__ = ["Container", "FrozenPyTreeNode", "field", "static_field", "zeros_like"]
 
 
-def field(*, pytree_node: bool = True, **kwargs):
+def _register_pytree_dataclass(
+    cls: type[Any], data_fields: Iterable[str], static_fields: Iterable[str]
+) -> None:
+    """Register a dataclass without routing PyTree reconstruction through ``__init__``.
+
+    JAX may unflatten a PyTree with opaque sentinel objects while determining vmap
+    axes.  Those sentinels are structural bookkeeping rather than user-provided
+    field values, so constructor and ``__post_init__`` validation must not see them.
+    Static values remain PyTree auxiliary data and therefore retain the semantics of
+    ``register_dataclass``.
+    """
+    data_names = tuple(data_fields)
+    static_names = tuple(static_fields)
+
+    def flatten_with_keys(
+        node: Any,
+    ) -> tuple[tuple[tuple[Any, Any], ...], tuple[Any, ...]]:
+        children = tuple((GetAttrKey(name), getattr(node, name)) for name in data_names)
+        static_values = tuple(getattr(node, name) for name in static_names)
+        return children, static_values
+
+    def flatten(node: Any) -> tuple[tuple[Any, ...], tuple[Any, ...]]:
+        children = tuple(getattr(node, name) for name in data_names)
+        static_values = tuple(getattr(node, name) for name in static_names)
+        return children, static_values
+
+    def unflatten(static_values: Iterable[Any], children: Iterable[Any]) -> Any:
+        # Bypass dataclass initialization only on JAX's reconstruction path. Normal
+        # calls to ``cls(...)`` still execute the generated initializer and all
+        # ``__post_init__`` validation.
+        node = object.__new__(cls)
+        for name, value in zip(data_names, children, strict=True):
+            object.__setattr__(node, name, value)
+        for name, value in zip(static_names, static_values, strict=True):
+            object.__setattr__(node, name, value)
+        return node
+
+    jax.tree_util.register_pytree_with_keys(
+        cls,
+        flatten_with_keys,
+        unflatten,
+        flatten_func=flatten,
+    )
+
+
+def field(*, pytree_node: bool = True, **kwargs: Any) -> Any:
     """
     Dataclass field helper. See `typing.FrozenPyTreeNode` for more details.
     Set `pytree_node=False` for static (non-transformed) fields.
@@ -19,12 +75,19 @@ def field(*, pytree_node: bool = True, **kwargs):
     return dataclasses.field(metadata=meta, **kwargs)
 
 
-def static_field(**kwargs):
-    """Shorthand for `field(pytree_node=False, ...)`."""
-    return field(pytree_node=False, **kwargs)
+def static_field(*, unsafe: bool = False, **kwargs: Any) -> Any:
+    """Declare a static (non-transformed) dataclass field.
+
+    Static values become part of a JAX pytree definition, so they must normally be
+    hashable. ``unsafe=True`` is an explicit escape hatch for opaque values whose
+    stability is managed by the caller.
+    """
+    meta = dict(kwargs.pop("metadata", {}) or {})
+    meta["static_field_unsafe"] = unsafe
+    return field(pytree_node=False, metadata=meta, **kwargs)
 
 
-@dataclass_transform()
+@dataclass_transform(field_specifiers=(field, static_field), frozen_default=True)
 class FrozenPyTreeNode:
     """
     Frozen dataclass base that is a JAX pytree node. Fields can be declared as either
@@ -40,7 +103,14 @@ class FrozenPyTreeNode:
         x = Foo(a={"w": 1.0}, b=0)
         y = x.replace(b=1)
         ```
+
+    Subclasses that define ``__post_init__`` must call ``super().__post_init__()``
+    so static fields are validated.
     """
+
+    # Type checkers can recognize instances as valid inputs to ``dataclasses.fields``
+    # and ``dataclasses.replace`` if we define this.
+    __dataclass_fields__: ClassVar[dict[str, dataclasses.Field[Any]]]
 
     # Turn subclasses into frozen dataclasses and register with JAX.
     def __init_subclass__(cls, *, dataclass_kwargs: dict[str, Any] | None = None, **kw):
@@ -62,7 +132,27 @@ class FrozenPyTreeNode:
             else:
                 static.append(f.name)
 
-        jax.tree_util.register_dataclass(cls, data, static)
+        _register_pytree_dataclass(cls, data, static)
+
+    def __post_init__(self):
+        self._validate_static_fields()
+
+    def _validate_static_fields(self) -> None:
+        for dataclass_field in dataclasses.fields(self):
+            if dataclass_field.metadata.get("pytree_node", True):
+                continue
+            if dataclass_field.metadata.get("static_field_unsafe", False):
+                continue
+
+            value = getattr(self, dataclass_field.name)
+            try:
+                hash(value)
+            except TypeError as error:
+                raise TypeError(
+                    f"static field {dataclass_field.name!r} on "
+                    f"{type(self).__name__} must be hashable; use "
+                    "static_field(unsafe=True) for caller-managed opaque metadata"
+                ) from error
 
     # convenience
     def replace(self, **changes):
@@ -70,7 +160,12 @@ class FrozenPyTreeNode:
         return dataclasses.replace(self, **changes)
 
 
-@dataclass_transform()
+def zeros_like(tree: PyTree) -> PyTree:
+    """Create a same-structure, same-shape/dtype zero tree."""
+    return jax.tree.map(lambda value: jnp.zeros_like(jnp.asarray(value)), tree)
+
+
+@dataclass_transform(frozen_default=True)
 @jax.tree_util.register_pytree_node_class
 @dataclasses.dataclass(frozen=True, eq=True, repr=True, slots=False)
 class Container:
@@ -124,19 +219,21 @@ class Container:
                 continue
             yield (f.name, getattr(self, f.name))
         # extras
-        for k, v in self._extras.items():
-            yield (k, v)
+        for key in sorted(self._extras):
+            yield (key, self._extras[key])
 
     def __str__(self) -> str:
         core_str = super().__str__()
         if not self._extras:
             return core_str
-        extras_str = f", {', '.join(f'{k}={v!r}' for k, v in self._extras.items())}"
+        extras_str = (f"{key}={self._extras[key]!r}" for key in sorted(self._extras))
+        extras_str = f", {', '.join(extras_str)}"
         return f"{core_str[:-1]}{extras_str})"  # remove closing parenthesis from core
 
-    def update(self, **changes: dict[str, PyTree]) -> Self:
+    def update(self, **changes: PyTree) -> Self:
         """Update the container with new values. The `changes` overwrite fields in the
-        container, both for core fields and extras.
+        container, both for core fields and extras. The annotation describes each
+        keyword value; Python collects those values into the ``changes`` dictionary.
 
         Args:
             **changes: A dictionary of field names and values to update.
@@ -155,6 +252,8 @@ class Container:
                 extras_updates[k] = v
 
         new = dataclasses.replace(self, **core_updates)
+        # Dictionaries preserve insertion order. Rebuilding from sorted pairs gives
+        # equal schemas the same flattening order regardless of update order.
         new_extras = dict(sorted({**self._extras, **extras_updates}.items()))
         object.__setattr__(new, "_extras", new_extras)
         return new
@@ -164,7 +263,7 @@ class Container:
         core_keys = tuple(f.name for f in core_fields)
         core_vals = tuple(getattr(self, name) for name in core_keys)
 
-        extras_keys = tuple(sorted(self._extras.keys()))
+        extras_keys = tuple(self._extras)
         extras_vals = tuple(self._extras[k] for k in extras_keys)
 
         children = core_vals + extras_vals

--- a/src/envelope/typing.py
+++ b/src/envelope/typing.py
@@ -1,6 +1,8 @@
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Any, Protocol, Self, TypeAlias, runtime_checkable
 
 import jax
+
+__all__ = ["Array", "Info", "Key", "PyTree", "State"]
 
 PyTree: TypeAlias = Any
 Key: TypeAlias = jax.Array  # with jnp.issubdtype(key.dtype, jax.dtypes.prng_key)
@@ -23,14 +25,21 @@ class Info(Protocol):
 
     """
 
-    obs: PyTree
-    reward: float
-    terminated: bool
-    truncated: bool
+    # Getter properties make the protocol read-only. Concrete implementations can
+    # still expose ordinary constructor fields, including frozen dataclass fields.
+    @property
+    def obs(self) -> PyTree: ...
 
-    def update(self, **changes: PyTree) -> "Info":
+    @property
+    def reward(self) -> float | Array: ...
+
+    @property
+    def terminated(self) -> bool | Array: ...
+
+    @property
+    def truncated(self) -> bool | Array: ...
+
+    def update(self, **changes: PyTree) -> Self:
         """Update the info container with new values. This method should return
         a new instance with updated and potentially new values."""
         ...
-
-    def __getattr__(self, name: str) -> PyTree: ...

--- a/src/envelope/wrappers/__init__.py
+++ b/src/envelope/wrappers/__init__.py
@@ -14,12 +14,25 @@ from envelope.wrappers.state_injection_wrapper import StateInjectionWrapper
 from envelope.wrappers.truncation_wrapper import TruncationWrapper
 from envelope.wrappers.vmap_envs_wrapper import VmapEnvsWrapper
 from envelope.wrappers.vmap_wrapper import VmapWrapper
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import (
+    PooledInitializationWrapper,
+    StackConstraint,
+    VectorizingWrapper,
+    WrappedState,
+    Wrapper,
+    not_containing,
+    not_inside,
+)
 
 __all__ = [
     # Basic functionality
     "Wrapper",
     "WrappedState",
+    "StackConstraint",
+    "VectorizingWrapper",
+    "PooledInitializationWrapper",
+    "not_inside",
+    "not_containing",
     # Wrappers
     "AutoResetWrapper",
     "ClipActionWrapper",

--- a/src/envelope/wrappers/autoreset_wrapper.py
+++ b/src/envelope/wrappers/autoreset_wrapper.py
@@ -1,34 +1,41 @@
-from typing import override
+from typing import ClassVar, override
 
 import jax
 import jax.numpy as jnp
 
 from envelope.environment import Info
-from envelope.struct import field
+from envelope.struct import field, zeros_like
 from envelope.typing import Key, PyTree
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import (
+    PooledInitializationWrapper,
+    VectorizingWrapper,
+    WrappedState,
+    Wrapper,
+    not_containing,
+    not_inside,
+)
 
 
 class AutoResetWrapper(Wrapper):
     """Wrapper that automatically resets the environment when an episode ends.
 
-    When a step results in termination or truncation, this wrapper immediately
-    resets the environment. The returned info preserves critical information
-    from the terminal step while providing the new episode's initial observation.
+    When a step results in termination or truncation, this wrapper immediately resets
+    the environment. The returned info preserves the information from the terminal step
+    while providing the new episode's initial observation.
 
     Info fields after a terminal step (terminated=True or truncated=True):
         obs: Initial observation from the new episode (after reset).
-        final: Full info snapshot from the terminal step (before reset).
-        terminated: True if the episode ended due to termination.
-        truncated: True if the episode ended due to truncation.
+        terminated: True if the last episode ended due to termination.
+        truncated: True if the last episode ended due to truncation.
         reward: Reward from the terminal step.
+        final: Full info snapshot from the terminal step (before reset).
 
     Info fields during normal steps (terminated=False and truncated=False):
         obs: Current observation.
-        final: Info snapshot from the last completed episode (persisted).
         terminated: False.
         truncated: False.
-        reward: Reward from the step.
+        reward: Reward from the current step.
+        final: Info snapshot from the last completed episode (persisted).
 
     This design enables correct value bootstrapping:
         - Use final.obs for value estimation of the true next state
@@ -41,42 +48,73 @@ class AutoResetWrapper(Wrapper):
     class AutoResetState(WrappedState):
         reset_key: jax.Array = field()
         last_final: Info = field()
+        final_valid: jax.Array = field()
+
+    stack_constraints: ClassVar = (
+        not_containing(VectorizingWrapper),
+        not_inside(PooledInitializationWrapper),
+    )
 
     @override
-    def init(self, key: Key) -> tuple[WrappedState, Info]:
-        key, subkey = jax.random.split(key)
-        inner_state, info = self.env.init(key)
-        # Initialize last_final with the reset info (no previous episode yet)
-        # Note that the placeholder that is returned only has nan values where it's
-        # dtype is a subdtype of float. TODO: Should we use empty_like?
-        last_final = jax.tree.map(lambda x: jnp.full_like(x, jnp.nan), info)
+    def init(self, key: Key) -> tuple[AutoResetState, Info]:
+        inner_key, reset_key = jax.random.split(key)
+        inner_state, info = self.env.init(inner_key)
+        last_final = zeros_like(info)
+        final_valid = jnp.asarray(False)
         state = self.AutoResetState(
-            inner_state=inner_state, reset_key=subkey, last_final=last_final
+            inner_state=inner_state,
+            reset_key=reset_key,
+            last_final=last_final,
+            final_valid=final_valid,
         )
-        return state, info.update(final=state.last_final)
+        return state, info.update(final=state.last_final, final_valid=final_valid)
 
     @override
-    def reset(self, state: WrappedState, key: Key) -> tuple[WrappedState, Info]:
-        raise NotImplementedError("Reset is not implemented for AutoResetWrapper")
+    def reset(self, state: AutoResetState, key: Key) -> tuple[AutoResetState, Info]:
+        inner_key, reset_key = jax.random.split(key)
+        inner_state, info = self.env.reset(state.inner_state, inner_key)
+        state = state.replace(inner_state=inner_state, reset_key=reset_key)
+        return state, info.update(final=state.last_final, final_valid=state.final_valid)
 
     @override
-    def step(self, state: WrappedState, action: PyTree) -> tuple[WrappedState, Info]:
-        key, key_reset = jax.random.split(state.reset_key)
-        state = state.replace(reset_key=key)
+    def step(
+        self, state: AutoResetState, action: PyTree
+    ) -> tuple[AutoResetState, Info]:
+        next_reset_key, reset_key = jax.random.split(state.reset_key)
+        transition_state, transition_info = self.env.step(state.inner_state, action)
+        done = transition_info.terminated | transition_info.truncated
 
-        inner_state, info = self.env.step(state.inner_state, action)
-        reset_inner_state, reset_info = self.env.reset(inner_state, key_reset)
+        def reset_episode():
+            reset_state, reset_info = self.env.reset(transition_state, reset_key)
+            terminal_info = reset_info.update(
+                reward=transition_info.reward,
+                terminated=transition_info.terminated,
+                truncated=transition_info.truncated,
+                final=transition_info,
+                final_valid=jnp.asarray(True),
+            )
+            return reset_state, transition_info, jnp.asarray(True), terminal_info
 
-        # Select next state and info based on done
-        done = info.terminated | info.truncated
-        state = jax.tree.map(
-            lambda reset, next: jax.lax.select(done, reset, next),
-            state.replace(inner_state=reset_inner_state),
-            state.replace(inner_state=inner_state),
+        def continue_episode():
+            continuing_info = transition_info.update(
+                final=state.last_final,
+                final_valid=state.final_valid,
+            )
+            return (
+                transition_state,
+                state.last_final,
+                state.final_valid,
+                continuing_info,
+            )
+
+        inner_state, last_final, final_valid, info = jax.lax.cond(
+            done, reset_episode, continue_episode
         )
-        info = jax.tree.map(
-            lambda reset, next: jax.lax.select(done, reset, next),
-            reset_info.update(final=info),
-            info.update(final=state.last_final),
+
+        state = state.replace(
+            inner_state=inner_state,
+            reset_key=next_reset_key,
+            last_final=last_final,
+            final_valid=final_valid,
         )
         return state, info

--- a/src/envelope/wrappers/continuous_observation_wrapper.py
+++ b/src/envelope/wrappers/continuous_observation_wrapper.py
@@ -5,13 +5,13 @@ import jax
 import jax.numpy as jnp
 
 from envelope.environment import Info, State
-from envelope.spaces import BatchedSpace, Continuous, Discrete, Space, peel_batched
+from envelope.spaces import Continuous, Discrete, Space, peel_batched, rebatch
 from envelope.typing import Key, PyTree
 from envelope.wrappers.wrapper import Wrapper
 
 
 def to_float(obs: PyTree) -> PyTree:
-    return jax.tree.map(lambda x: x.astype(jnp.float32), obs)
+    return jax.tree.map(lambda x: jnp.asarray(x, dtype=jnp.float32), obs)
 
 
 def to_continuous(space: Discrete | Continuous) -> Continuous:
@@ -46,8 +46,8 @@ class ContinuousObservationWrapper(Wrapper):
         info = info.update(obs=to_float(info.obs))
         return state, info
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> Space:
         batch_dims, base = peel_batched(self.env.observation_space)
 
@@ -56,6 +56,4 @@ class ContinuousObservationWrapper(Wrapper):
 
         space = jax.tree.map(to_continuous, base, is_leaf=is_leaf)
 
-        for batch_dim in batch_dims:
-            space = BatchedSpace(space, batch_dim)
-        return space
+        return rebatch(space, batch_dims)

--- a/src/envelope/wrappers/episode_statistics_wrapper.py
+++ b/src/envelope/wrappers/episode_statistics_wrapper.py
@@ -1,6 +1,7 @@
 from typing import override
 
 import jax
+import jax.numpy as jnp
 
 from envelope.environment import Info, State
 from envelope.struct import FrozenPyTreeNode, field
@@ -20,13 +21,14 @@ class EpisodeStatisticsWrapper(Wrapper):
     @override
     def init(self, key: Key) -> tuple[State, Info]:
         inner_state, info = self.env.init(key)
-        state = self.EpisodeStatisticsState(inner_state=inner_state)
+        stats = _zero_stats(info)
+        state = self.EpisodeStatisticsState(inner_state=inner_state, stats=stats)
         return state, info.update(stats=state.stats)
 
     @override
     def reset(self, state: State, key: Key) -> tuple[State, Info]:
         inner_state, info = self.env.reset(state.inner_state, key)
-        state = state.replace(inner_state=inner_state)
+        state = state.replace(inner_state=inner_state, stats=_zero_stats(info))
         return state, info.update(stats=state.stats)
 
     @override
@@ -38,3 +40,10 @@ class EpisodeStatisticsWrapper(Wrapper):
         )
         state = state.replace(inner_state=inner_state, stats=stats)
         return state, info.update(stats=stats)
+
+
+def _zero_stats(info: Info) -> EpisodeStatistics:
+    return EpisodeStatistics(
+        reward=jnp.zeros_like(info.reward),
+        length=jnp.zeros_like(info.reward, dtype=jnp.int32),
+    )

--- a/src/envelope/wrappers/flatten_action_wrapper.py
+++ b/src/envelope/wrappers/flatten_action_wrapper.py
@@ -1,23 +1,17 @@
 from functools import cached_property
+from math import prod
 from typing import override
 
 import jax
 import jax.numpy as jnp
 
 from envelope.environment import Info, State
-from envelope.spaces import (
-    BatchedSpace,
-    Continuous,
-    Discrete,
-    PyTreeSpace,
-    Space,
-    peel_batched,
-)
+from envelope.spaces import Continuous, Discrete, Space, peel_batched, rebatch
 from envelope.typing import PyTree
 from envelope.wrappers.wrapper import Wrapper
 
 
-def flatten_space(space: PyTreeSpace | Continuous | Discrete):
+def flatten_space(space: Space):
     def is_leaf(x):
         # Tuples containing only integers are shape tuples (leaves)
         # PyTreeSpace can only have tuples that contain at least a Space, so
@@ -25,26 +19,27 @@ def flatten_space(space: PyTreeSpace | Continuous | Discrete):
         return isinstance(x, tuple) and all(isinstance(i, int) for i in x)
 
     shapes, treedef = jax.tree.flatten(space.shape, is_leaf=is_leaf)
-    dims = [jnp.prod(jnp.asarray(shape)) for shape in shapes]
+    dims = [prod(shape) for shape in shapes]
     return treedef, shapes, dims
 
 
 def unflatten_x(x: jax.Array, treedef, shapes, dims):
-    indices = jnp.cumsum(jnp.array(dims))[:-1]  # last split is the remainder
-    xs = jnp.split(x, indices)
-    xs = jax.tree.map(lambda x, shape: x.reshape(shape), xs, shapes)
+    indices = tuple(sum(dims[:i]) for i in range(1, len(dims)))
+    xs = jnp.split(x, indices, axis=-1)
+    xs = [p.reshape(p.shape[:-1] + tuple(shape)) for p, shape in zip(xs, shapes)]
     return jax.tree.unflatten(treedef, xs)
 
 
 class FlattenActionWrapper(Wrapper):
     @override
     def step(self, state: State, action: PyTree) -> tuple[State, Info]:
-        treedef, shapes, dims = flatten_space(self.env.action_space)
+        _, base = peel_batched(self.env.action_space)
+        treedef, shapes, dims = flatten_space(base)
         action = unflatten_x(action, treedef, shapes, dims)
         return self.env.step(state, action)
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> Space:
         batch_dims, base = peel_batched(self.env.action_space)
 
@@ -70,6 +65,4 @@ class FlattenActionWrapper(Wrapper):
         else:
             raise ValueError(f"Unsupported space type: {act_cls}")
 
-        for batch_dim in batch_dims:
-            space = BatchedSpace(space, batch_dim)
-        return space
+        return rebatch(space, batch_dims)

--- a/src/envelope/wrappers/flatten_observation_wrapper.py
+++ b/src/envelope/wrappers/flatten_observation_wrapper.py
@@ -5,50 +5,47 @@ import jax
 import jax.numpy as jnp
 
 from envelope.environment import Info, State
-from envelope.spaces import BatchedSpace, Continuous, Discrete, Space, peel_batched
+from envelope.spaces import Continuous, Discrete, Space, peel_batched, rebatch
 from envelope.typing import Key, PyTree
 from envelope.wrappers.wrapper import Wrapper
 
 
-def flatten_space(space: Space):
-    def is_leaf(x):
-        # Tuples containing only integers are shape tuples (leaves)
-        # PyTreeSpace can only have tuples that contain at least a Space, so
-        # tuples with only integers must be shape tuples from leaf spaces
-        return isinstance(x, tuple) and all(isinstance(i, int) for i in x)
+def flatten_x(x: PyTree, batch_ndim: int = 0):
+    def _reshape_leaf(leaf):
+        leaf = jnp.asarray(leaf)
+        return leaf.reshape(leaf.shape[:batch_ndim] + (-1,))
 
-    shapes, treedef = jax.tree.flatten(space.shape, is_leaf=is_leaf)
-    dims = [jnp.prod(jnp.asarray(shape)) for shape in shapes]
-    return treedef, shapes, dims
-
-
-def flatten_x(x: PyTree):
     leaves = jax.tree.leaves(x)
-    xs = jax.tree.map(lambda x: jnp.asarray(x).reshape(-1), leaves)
-    x = jnp.concatenate(xs, axis=0)
+    xs = [_reshape_leaf(leaf) for leaf in leaves]
+    x = jnp.concatenate(xs, axis=-1)
     return x
 
 
 class FlattenObservationWrapper(Wrapper):
+    def _flatten_obs(self, obs: PyTree) -> jax.Array:
+        batch_dims, _ = peel_batched(self.env.observation_space)
+        return flatten_x(obs, batch_ndim=len(batch_dims))
+
     @override
     def init(self, key: Key) -> tuple[State, Info]:
         state, info = self.env.init(key)
-        info = info.update(obs=flatten_x(info.obs))
+        info = info.update(obs=self._flatten_obs(info.obs))
         return state, info
 
     @override
     def reset(self, state: State, key: Key) -> tuple[State, Info]:
-        next_state, info = self.env.reset(state, key)
-        return next_state, info.update(obs=flatten_x(info.obs))
+        state, info = self.env.reset(state, key)
+        info = info.update(obs=self._flatten_obs(info.obs))
+        return state, info
 
     @override
     def step(self, state: State, action: PyTree) -> tuple[State, Info]:
         state, info = self.env.step(state, action)
-        info = info.update(obs=flatten_x(info.obs))
+        info = info.update(obs=self._flatten_obs(info.obs))
         return state, info
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> Space:
         batch_dims, base = peel_batched(self.env.observation_space)
 
@@ -75,6 +72,4 @@ class FlattenObservationWrapper(Wrapper):
         else:
             raise ValueError(f"Unsupported space type: {obs_cls}")
 
-        for batch_dim in batch_dims:
-            space = BatchedSpace(space, batch_dim)
-        return space
+        return rebatch(space, batch_dims)

--- a/src/envelope/wrappers/normalization.py
+++ b/src/envelope/wrappers/normalization.py
@@ -1,5 +1,4 @@
 from functools import cached_property
-from typing import NamedTuple
 
 import jax
 from jax import numpy as jnp
@@ -8,31 +7,30 @@ from envelope.struct import FrozenPyTreeNode
 from envelope.typing import Array, PyTree
 
 
-class MeanVarPair(NamedTuple):
-    mean: Array
-    var: Array
-
-
 class RunningMeanVar(FrozenPyTreeNode):
     mean: PyTree
     var: PyTree
-    count: int | Array
+    count: PyTree
 
     @cached_property
     def std(self) -> PyTree:
-        return jax.tree.map(jnp.sqrt, self.var)
+        return jax.tree.map(lambda var: jnp.sqrt(jnp.maximum(var, 0)), self.var)
 
 
 def update_rmv(rmv_state: RunningMeanVar, x: PyTree) -> RunningMeanVar:
     """
-    Update running mean/variance with a new batch of observations x. We assume x is a
-    PyTree of arrays, each with a leading batch dimension (aligned sizes).
+    Update running mean/variance with new observation batches. Each leaf has its own
+    leading sample dimension and count, so broadcast-reduced leaves may consume
+    different effective batch sizes.
     """
-    global_count = rmv_state.count
-    batch_count = jax.tree.leaves(x)[0].shape[0]
-    tot_count = global_count + batch_count
 
-    def _update_arr(mean: Array, var: Array, x_arr: Array) -> MeanVarPair:
+    def _update(
+        mean: Array, var: Array, global_count: Array, x_arr: Array
+    ) -> RunningMeanVar:
+        x_arr = jnp.asarray(x_arr, dtype=jnp.asarray(mean).dtype)
+        global_count = jnp.asarray(global_count)
+        batch_count = jnp.asarray(x_arr.shape[0], dtype=global_count.dtype)
+        total_count = global_count + batch_count
         batch_mean = x_arr.mean(axis=0)
         batch_var = x_arr.var(axis=0)
 
@@ -40,17 +38,17 @@ def update_rmv(rmv_state: RunningMeanVar, x: PyTree) -> RunningMeanVar:
         m_a = var * global_count
         m_b = batch_var * batch_count
         delta = batch_mean - mean
-        m2 = m_a + m_b + (delta**2) * (global_count * batch_count) / tot_count
+        m2 = m_a + m_b + (delta**2) * (global_count * batch_count) / total_count
 
-        new_mean = mean + delta * (batch_count / tot_count)
-        new_var = m2 / tot_count
-        return MeanVarPair(mean=new_mean, var=new_var)
+        new_mean = mean + delta * (batch_count / total_count)
+        new_var = jnp.maximum(m2 / total_count, 0)
+        return RunningMeanVar(mean=new_mean, var=new_var, count=total_count)
 
-    def is_pair(z):
-        return isinstance(z, MeanVarPair)
+    def is_result(z):
+        return isinstance(z, RunningMeanVar)
 
-    # jax.tree.map returns a PyTree whose leaves are MeanVarPairs
-    mean_var_pairs = jax.tree.map(_update_arr, rmv_state.mean, rmv_state.var, x)
-    new_mean = jax.tree.map(lambda mv: mv.mean, mean_var_pairs, is_leaf=is_pair)
-    new_var = jax.tree.map(lambda mv: mv.var, mean_var_pairs, is_leaf=is_pair)
-    return RunningMeanVar(mean=new_mean, var=new_var, count=tot_count)
+    results = jax.tree.map(_update, rmv_state.mean, rmv_state.var, rmv_state.count, x)
+    new_mean = jax.tree.map(lambda result: result.mean, results, is_leaf=is_result)
+    new_var = jax.tree.map(lambda result: result.var, results, is_leaf=is_result)
+    new_count = jax.tree.map(lambda result: result.count, results, is_leaf=is_result)
+    return RunningMeanVar(mean=new_mean, var=new_var, count=new_count)

--- a/src/envelope/wrappers/observation_normalization_wrapper.py
+++ b/src/envelope/wrappers/observation_normalization_wrapper.py
@@ -1,22 +1,43 @@
 from functools import cached_property
-from typing import override
+from math import prod
+from typing import Any, ClassVar, cast, override
 
 import jax
 from jax import numpy as jnp
 
 from envelope.environment import Info
-from envelope.spaces import BatchedSpace, Continuous, Discrete, PyTreeSpace, Space
+from envelope.spaces import (
+    BatchedSpace,
+    Continuous,
+    PyTreeSpace,
+    Space,
+    peel_batched,
+    rebatch,
+)
 from envelope.struct import field, static_field
 from envelope.typing import Key, PyTree
 from envelope.wrappers.normalization import RunningMeanVar, update_rmv
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import (
+    PooledInitializationWrapper,
+    WrappedState,
+    Wrapper,
+    not_inside,
+)
 
 
 class ObservationNormalizationWrapper(Wrapper):
+    """Normalize a batch with shared running statistics.
+
+    If the inner stack emits ``final``, the wrapper also normalizes ``final.obs`` while
+    retaining the raw terminal observation as ``final.unnormalized_obs``.
+    """
+
+    stack_constraints: ClassVar = (not_inside(PooledInitializationWrapper),)
+
     class ObservationNormalizationState(WrappedState):
         rmv_state: RunningMeanVar = field()
 
-    stats_spec: PyTree | None = static_field(default=None)
+    stats_spec: PyTree | None = static_field(default=None, unsafe=True)
     """Per-leaf normalization statistics spec as a pytree of jax.ShapeDtypeStruct.
     Shapes must be broadcastable to the observation leaves. If None, inferred from
     the observation_space with BatchedSpace ignored; each leaf must have a floating
@@ -26,21 +47,26 @@ class ObservationNormalizationWrapper(Wrapper):
         if self.stats_spec is None:
             stats_spec = _infer_stats_spec(self.env.observation_space)
             object.__setattr__(self, "stats_spec", stats_spec)
+        super().__post_init__()
 
     def _init_rmv_state(self) -> RunningMeanVar:
         def zeros(sd: jax.ShapeDtypeStruct) -> jax.Array:
-            return jnp.zeros(sd.shape, dtype=sd.dtype)
+            dtype = jnp.result_type(sd.dtype, jnp.float32)
+            return jnp.zeros(sd.shape, dtype=dtype)
 
         def ones(sd: jax.ShapeDtypeStruct) -> jax.Array:
-            return jnp.ones(sd.shape, dtype=sd.dtype)
+            dtype = jnp.result_type(sd.dtype, jnp.float32)
+            return jnp.ones(sd.shape, dtype=dtype)
 
         mean = jax.tree.map(zeros, self.stats_spec)
         var = jax.tree.map(ones, self.stats_spec)
+        count = jax.tree.map(lambda _: jnp.asarray(0), self.stats_spec)
 
-        return RunningMeanVar(mean=mean, var=var, count=jnp.asarray(0))
+        return RunningMeanVar(mean=mean, var=var, count=count)
 
     def _normalize_obs(self, obs: PyTree, rmv: RunningMeanVar) -> PyTree:
         def norm_leaf(x, mean, std, spec):
+            x = jnp.asarray(x, dtype=mean.dtype)
             mean = jnp.broadcast_to(mean, x.shape)
             std = jnp.broadcast_to(std, x.shape)
             obs = (x - mean) / (std + 1e-8)
@@ -49,57 +75,109 @@ class ObservationNormalizationWrapper(Wrapper):
         return jax.tree.map(norm_leaf, obs, rmv.mean, rmv.std, self.stats_spec)
 
     def _normalize_and_update(
-        self, state: WrappedState, info: Info
-    ) -> tuple[WrappedState, Info]:
-        # Ensure each observation leaf is shaped as (-1, *spec.shape)
-        reshaped_obs = jax.tree.map(
-            lambda x, spec: x.reshape((-1,) + tuple(spec.shape)),
-            info.obs,
-            self.stats_spec,
-        )
+        self, state: ObservationNormalizationState, info: Info
+    ) -> tuple[ObservationNormalizationState, Info]:
+        raw_obs = info.obs
+        reshaped_obs = jax.tree.map(_reshape_for_stats, raw_obs, self.stats_spec)
         rmv_state = update_rmv(state.rmv_state, reshaped_obs)
-        norm_obs = self._normalize_obs(info.obs, rmv_state)
+        norm_obs = self._normalize_obs(raw_obs, rmv_state)
 
-        state = self.ObservationNormalizationState(
-            inner_state=state.inner_state, rmv_state=rmv_state
-        )
-        info = info.update(obs=norm_obs, unnormalized_obs=info.obs)
+        info = info.update(obs=norm_obs, unnormalized_obs=raw_obs)
+
+        if hasattr(info, "final") and hasattr(info, "final_valid"):
+            info_with_final = cast(Any, info)
+            raw_final_obs = info_with_final.final.obs
+            norm_final_obs = jax.tree.map(
+                lambda obs: _mask_valid(info_with_final.final_valid, obs),
+                self._normalize_obs(raw_final_obs, rmv_state),
+            )
+
+            final = info_with_final.final.update(
+                obs=norm_final_obs, unnormalized_obs=raw_final_obs
+            )
+            info = info.update(final=final)
+
+        state = state.replace(rmv_state=rmv_state)
         return state, info
 
     @override
-    def init(self, key: Key) -> tuple[WrappedState, Info]:
+    def init(self, key: Key) -> tuple[ObservationNormalizationState, Info]:
         inner_state, info = self.env.init(key)
         rmv_state = self._init_rmv_state()
         next_state = self.ObservationNormalizationState(
-            inner_state=inner_state, rmv_state=rmv_state
+            inner_state=inner_state,
+            rmv_state=rmv_state,
         )
         return self._normalize_and_update(next_state, info)
 
     @override
-    def reset(self, state: WrappedState, key: Key) -> tuple[WrappedState, Info]:
+    def reset(
+        self, state: ObservationNormalizationState, key: Key
+    ) -> tuple[ObservationNormalizationState, Info]:
         inner_state, info = self.env.reset(state.inner_state, key)
         # Preserve running statistics across resets
-        next_state = self.ObservationNormalizationState(
-            inner_state=inner_state, rmv_state=state.rmv_state
-        )
-        return self._normalize_and_update(next_state, info)
-
-    @override
-    def step(self, state: WrappedState, action: PyTree) -> tuple[WrappedState, Info]:
-        inner_state, info = self.env.step(state.inner_state, action)
         state = state.replace(inner_state=inner_state)
         return self._normalize_and_update(state, info)
 
     @override
+    def step(
+        self, state: ObservationNormalizationState, action: PyTree
+    ) -> tuple[ObservationNormalizationState, Info]:
+        inner_state, info = self.env.step(state.inner_state, action)
+        state = state.replace(inner_state=inner_state)
+        return self._normalize_and_update(state, info)
+
     @cached_property
+    @override
     def observation_space(self) -> Space:
-        def to_continuous(space: Continuous | Discrete) -> Continuous:
-            return Continuous.from_shape(low=-jnp.inf, high=jnp.inf, shape=space.shape)
+        batch_dims, base = peel_batched(self.env.observation_space)
+        stats_spec = cast(Any, self.stats_spec)
 
-        def is_leaf(space: Space) -> bool:
-            return isinstance(space, (Discrete, Continuous))
+        def to_continuous(inner_space: Space, spec: jax.ShapeDtypeStruct) -> Continuous:
+            low = jnp.full(inner_space.shape, -jnp.inf, dtype=spec.dtype)
+            high = jnp.full(inner_space.shape, jnp.inf, dtype=spec.dtype)
+            return Continuous(low=low, high=high)
 
-        return jax.tree.map(to_continuous, self.env.observation_space, is_leaf=is_leaf)
+        if isinstance(base, PyTreeSpace):
+            tree = jax.tree.map(
+                to_continuous,
+                base.tree,
+                stats_spec,
+                is_leaf=lambda node: isinstance(node, Space),
+            )
+            space: Space = PyTreeSpace(tree)
+        else:
+            space = to_continuous(base, stats_spec)
+        return rebatch(space, batch_dims)
+
+
+def _reshape_for_stats(x: jax.Array, spec: jax.ShapeDtypeStruct) -> jax.Array:
+    """Turn leading and broadcast axes into samples."""
+    x = jnp.asarray(x)
+    spec_shape = tuple(spec.shape)
+    offset = x.ndim - len(spec_shape)
+    sample_axes = list(range(offset))
+    statistic_axes: list[int] = []
+    for index, spec_dim in enumerate(spec_shape):
+        axis = offset + index
+        if spec_dim == 1:
+            sample_axes.append(axis)
+        else:
+            statistic_axes.append(axis)
+
+    permutation = tuple(sample_axes + statistic_axes)
+    if permutation != tuple(range(x.ndim)):
+        x = jnp.transpose(x, permutation)
+    sample_count = prod(x.shape[: len(sample_axes)]) if sample_axes else 1
+    return x.reshape((sample_count,) + spec_shape)
+
+
+def _mask_valid(valid: PyTree, obs: jax.Array) -> jax.Array:
+    """Zero invalid batch elements without crossing event dimensions."""
+    valid = jnp.asarray(valid, dtype=jnp.bool_)
+    obs = jnp.asarray(obs)
+    mask = valid.reshape(valid.shape + (1,) * (obs.ndim - valid.ndim))
+    return jnp.where(mask, obs, jnp.zeros_like(obs))
 
 
 def _infer_stats_spec(space: Space) -> PyTree:

--- a/src/envelope/wrappers/pooled_init_vmap_wrapper.py
+++ b/src/envelope/wrappers/pooled_init_vmap_wrapper.py
@@ -1,122 +1,142 @@
 from functools import cached_property
-from typing import override
+from typing import ClassVar, override
 
 import jax
 import jax.numpy as jnp
 
 from envelope import spaces
 from envelope.environment import Info
-from envelope.struct import field
+from envelope.struct import field, static_field, zeros_like
 from envelope.typing import Key, PyTree
 from envelope.wrappers.vmap_wrapper import _split_or_keep_key
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import (
+    PooledInitializationWrapper,
+    VectorizingWrapper,
+    WrappedState,
+    Wrapper,
+    not_containing,
+)
 
 
-class PooledInitVmapWrapper(Wrapper):
-    batch_size: int = field(kw_only=True)
-    pool_size: int = field(kw_only=True)
+class PooledInitVmapWrapper(
+    Wrapper, VectorizingWrapper, PooledInitializationWrapper
+):
+    """Vectorize environments using lazily generated init states.
+
+    Explicit ``reset`` calls still invoke the inner environment's vectorized ``reset``;
+    pooled ``init`` results are used only for automatic episode boundaries in ``step``.
+    """
+
+    batch_size: int = static_field(kw_only=True)
+    pool_size: int = static_field(kw_only=True)
+
+    stack_constraints: ClassVar = (not_containing(VectorizingWrapper),)
 
     class PooledInitVmapState(WrappedState):
         init_key: Key = field()
         last_final: Info = field()
+        final_valid: jax.Array = field()
 
     @override
-    def init(self, key: Key) -> tuple[WrappedState, Info]:
+    def init(self, key: Key) -> tuple[PooledInitVmapState, Info]:
         keys = _split_or_keep_key(key, self.batch_size + 1)
         key_next, keys_pool = keys[0], keys[1:]
         inner_state, info = jax.vmap(self.env.init)(keys_pool)
-
-        # Note that the placeholder that is returned only has nan values where it's
-        # dtype is a subdtype of float. TODO: Should we use empty_like?
-        pholder_info = jax.tree.map(lambda x: jnp.full_like(x, jnp.nan), info)
+        last_final = zeros_like(info)
+        final_valid = jnp.zeros((self.batch_size,), dtype=jnp.bool_)
         state = self.PooledInitVmapState(
             inner_state=inner_state,
             init_key=key_next,
-            last_final=pholder_info,
+            last_final=last_final,
+            final_valid=final_valid,
         )
-        return state, info.update(final=pholder_info)
+        return state, info.update(final=last_final, final_valid=final_valid)
 
     @override
-    def reset(self, state: WrappedState, key: Key) -> tuple[WrappedState, Info]:
-        # It's hard to support reset for this wrapper.
-        # We would have to init the state of a pool of unwrapped environments, and then
-        # somehow inject this into the stack of wrapped states. The current data
-        # structure for wrapped states does not make this possible without being super
-        # hacky, and violating the assumption that wrapped states are opaque (we would
-        # likely have to recursively descend by checking if
-        # hasattr(state, "inner_state")).
-        # Since there is currently no use case in which we need to carry state across
-        # episodes before vmapping, we will implement this later.
+    def reset(
+        self, state: PooledInitVmapState, key: Key
+    ) -> tuple[PooledInitVmapState, Info]:
+        # Explicit resets are not pooled: reset every current inner state normally.
         keys = _split_or_keep_key(key, self.batch_size + 1)
         key_next, keys_pool = keys[0], keys[1:]
         inner_state, info = jax.vmap(self.env.reset)(state.inner_state, keys_pool)
         state = state.replace(inner_state=inner_state, init_key=key_next)
-        return state, info.update(final=state.last_final)
+        return state, info.update(final=state.last_final, final_valid=state.final_valid)
 
     @override
-    def step(self, state: WrappedState, action: PyTree) -> tuple[WrappedState, Info]:
-        inner_state, info = jax.vmap(self.env.step)(state.inner_state, action)
-        done = info.terminated | info.truncated
+    def step(
+        self, state: PooledInitVmapState, action: PyTree
+    ) -> tuple[PooledInitVmapState, Info]:
+        transition_state, transition_info = jax.vmap(self.env.step)(
+            state.inner_state, action
+        )
+        done = transition_info.terminated | transition_info.truncated
 
-        # Compute pool_size fresh init states
-        key_pool = jax.random.fold_in(state.init_key, 0)
         next_init_key = jax.random.fold_in(state.init_key, 1)
-        keys_pool = jax.random.split(key_pool, self.pool_size)
-        inner_states_pool, infos_pool = jax.vmap(self.env.init)(keys_pool)
-
-        # Randomly assign each env a init state from the pool
-        key_idxs = jax.random.fold_in(state.init_key, 2)
-        pool_idxs = jax.random.randint(key_idxs, (self.batch_size,), 0, self.pool_size)
-
-        # Expand pool states to batch_size via indexing
-        mapped_init_state = jax.tree.map(lambda x: x[pool_idxs], inner_states_pool)
-        mapped_init_info = jax.tree.map(lambda x: x[pool_idxs], infos_pool)
-
-        # Select inner_state: init for done envs, continue for others
-        final_inner_state = jax.tree.map(
-            lambda init, curr: jax.vmap(jnp.where)(done, init, curr),
-            mapped_init_state,
-            inner_state,
+        continuing_info = transition_info.update(
+            final=state.last_final, final_valid=state.final_valid
         )
 
-        # Select last_final: on done, store terminal info; on continue, keep previous
-        final_last_final = jax.tree.map(
-            lambda curr, prev: jax.vmap(jnp.where)(done, curr, prev),
-            info,
-            state.last_final,
-        )
+        def construct_pool(_):
+            key_pool = jax.random.fold_in(state.init_key, 0)
+            keys_pool = jax.random.split(key_pool, self.pool_size)
+            inner_states_pool, infos_pool = jax.vmap(self.env.init)(keys_pool)
 
-        # Build final_info with final field
-        # For done envs: obs is new initial obs, final is terminal info
-        # For continue envs: obs is current obs, final is previous last_final
-        final_obs = jax.tree.map(
-            lambda init, curr: jax.vmap(jnp.where)(done, init, curr),
-            mapped_init_info.obs,
-            info.obs,
+            key_idxs = jax.random.fold_in(state.init_key, 2)
+            pool_idxs = jax.random.randint(
+                key_idxs, (self.batch_size,), 0, self.pool_size
+            )
+            mapped_init_state = jax.tree.map(lambda x: x[pool_idxs], inner_states_pool)
+            mapped_init_info = jax.tree.map(lambda x: x[pool_idxs], infos_pool)
+
+            def select(on_done, on_continue):
+                return jax.vmap(jnp.where)(done, on_done, on_continue)
+
+            final_inner_state = jax.tree.map(
+                select, mapped_init_state, transition_state
+            )
+            final_last_final = jax.tree.map(select, transition_info, state.last_final)
+            final_valid = state.final_valid | done
+
+            terminal_info = mapped_init_info.update(
+                reward=transition_info.reward,
+                terminated=transition_info.terminated,
+                truncated=transition_info.truncated,
+                final=transition_info,
+                final_valid=jnp.ones((self.batch_size,), dtype=jnp.bool_),
+            )
+            final_info = jax.tree.map(select, terminal_info, continuing_info)
+            return final_inner_state, final_last_final, final_valid, final_info
+
+        def keep_transitions(_):
+            return (
+                transition_state,
+                state.last_final,
+                state.final_valid,
+                continuing_info,
+            )
+
+        final_inner_state, final_last_final, final_valid, final_info = jax.lax.cond(
+            jnp.any(done), construct_pool, keep_transitions, operand=None
         )
-        final_final = jax.tree.map(
-            lambda curr, prev: jax.vmap(jnp.where)(done, curr, prev),
-            info,  # Terminal info snapshot for done envs
-            state.last_final,  # Previous episode's final for continue envs
-        )
-        final_info = info.update(obs=final_obs, final=final_final)
 
         state = state.replace(
             inner_state=final_inner_state,
             init_key=next_init_key,
             last_final=final_last_final,
+            final_valid=final_valid,
         )
         return state, final_info
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> spaces.Space:
         return spaces.BatchedSpace(
             space=self.env.observation_space, batch_size=self.batch_size
         )
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> spaces.Space:
         return spaces.BatchedSpace(
             space=self.env.action_space, batch_size=self.batch_size

--- a/src/envelope/wrappers/pooled_init_vmap_wrapper.py
+++ b/src/envelope/wrappers/pooled_init_vmap_wrapper.py
@@ -18,9 +18,7 @@ from envelope.wrappers.wrapper import (
 )
 
 
-class PooledInitVmapWrapper(
-    Wrapper, VectorizingWrapper, PooledInitializationWrapper
-):
+class PooledInitVmapWrapper(Wrapper, VectorizingWrapper, PooledInitializationWrapper):
     """Vectorize environments using lazily generated init states.
 
     Explicit ``reset`` calls still invoke the inner environment's vectorized ``reset``;

--- a/src/envelope/wrappers/state_injection_wrapper.py
+++ b/src/envelope/wrappers/state_injection_wrapper.py
@@ -1,9 +1,17 @@
-from typing import override
+from typing import ClassVar, override
 
-from envelope.environment import Info, InfoContainer
+import jax
+import jax.numpy as jnp
+
+from envelope.environment import Info
 from envelope.struct import field
 from envelope.typing import Key, PyTree
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import (
+    PooledInitializationWrapper,
+    WrappedState,
+    Wrapper,
+    not_inside,
+)
 
 
 class StateInjectionWrapper(Wrapper):
@@ -19,8 +27,10 @@ class StateInjectionWrapper(Wrapper):
 
         for outer_iter in range(num_outer_iters):
             # Sample a new task and set it as the reset state
-            task_state, task_obs = sample_task(key)
-            state = env.set_reset_state(state, task_state, task_obs)
+            task_state, task_info = sample_task(key)
+            state = env.set_reset_state(
+                state, task_state, reset_info=task_info
+            )
 
             # Run episode - auto-resets return to task_state
             for inner_step in range(num_inner_steps):
@@ -28,12 +38,19 @@ class StateInjectionWrapper(Wrapper):
         ```
     """
 
+    stack_constraints: ClassVar = (not_inside(PooledInitializationWrapper),)
+
     class InjectedState(WrappedState):
-        reset_state: PyTree | None = field(default=None)
-        reset_obs: PyTree | None = field(default=None)
+        reset_state: PyTree = field()
+        reset_info: Info = field()
+        active: jax.Array = field()
 
     def set_reset_state(
-        self, state: WrappedState, reset_state: PyTree, reset_obs: PyTree
+        self,
+        state: WrappedState,
+        reset_state: PyTree,
+        *,
+        reset_info: Info,
     ) -> WrappedState:
         """Update the state that resets will return to.
 
@@ -43,7 +60,8 @@ class StateInjectionWrapper(Wrapper):
         Args:
             state: Current state (can be from any outer wrapper)
             reset_state: The state to reset to (inner environment state)
-            reset_obs: The observation to return on reset
+            reset_info: The complete info value to return on reset. Its PyTree
+                structure must match the environment's normal reset info.
 
         Returns:
             New state with updated reset fields at the appropriate level
@@ -52,10 +70,11 @@ class StateInjectionWrapper(Wrapper):
         def update_injected(s: WrappedState) -> WrappedState:
             # If this is our InjectedState, update it
             if isinstance(s, self.InjectedState):
-                return self.InjectedState(
+                return s.replace(
                     inner_state=reset_state,
                     reset_state=reset_state,
-                    reset_obs=reset_obs,
+                    reset_info=reset_info,
+                    active=jnp.asarray(True),
                 )
             # Otherwise, recurse into inner_state and rebuild
             if hasattr(s, "inner_state"):
@@ -65,25 +84,30 @@ class StateInjectionWrapper(Wrapper):
         return update_injected(state)
 
     @override
-    def init(self, key: Key) -> tuple[WrappedState, Info]:
+    def init(self, key: Key) -> tuple[InjectedState, Info]:
         inner_state, info = self.env.init(key)
-        state = self.InjectedState(inner_state=inner_state)
+        state = self.InjectedState(
+            inner_state=inner_state,
+            reset_state=inner_state,
+            reset_info=info,
+            active=jnp.asarray(False),
+        )
         return state, info
 
     @override
-    def reset(self, state: WrappedState, key: Key) -> tuple[WrappedState, Info]:
-        # If reset state is set, use it instead of resetting inner env
-        if state.reset_state is not None and state.reset_obs is not None:
-            inner_state = state.reset_state
-            info = InfoContainer(obs=state.reset_obs, reward=0.0, terminated=False)
-        elif state.reset_state is None and state.reset_obs is None:
-            inner_state, info = self.env.reset(state.inner_state, key)
-        else:
-            raise ValueError("State must set both reset_state and reset_obs or neither")
+    def reset(self, state: InjectedState, key: Key) -> tuple[InjectedState, Info]:
+        def injected(_):
+            return state.reset_state, state.reset_info
 
+        def delegated(_):
+            return self.env.reset(state.inner_state, key)
+
+        inner_state, info = jax.lax.cond(
+            state.active, injected, delegated, operand=None
+        )
         return state.replace(inner_state=inner_state), info
 
     @override
-    def step(self, state: WrappedState, action: PyTree) -> tuple[WrappedState, Info]:
+    def step(self, state: InjectedState, action: PyTree) -> tuple[InjectedState, Info]:
         inner_state, info = self.env.step(state.inner_state, action)
         return state.replace(inner_state=inner_state), info

--- a/src/envelope/wrappers/truncation_wrapper.py
+++ b/src/envelope/wrappers/truncation_wrapper.py
@@ -14,22 +14,29 @@ class TruncationWrapper(Wrapper):
     class TruncationState(WrappedState):
         steps: jnp.ndarray | int = field(default=0)
 
+    def __post_init__(self):
+        if self.max_steps <= 0:
+            raise ValueError("max_steps must be greater than zero")
+        super().__post_init__()
+
     @override
-    def init(self, key: Key) -> tuple[WrappedState, Info]:
+    def init(self, key: Key) -> tuple[TruncationState, Info]:
         inner_state, info = self.env.init(key)
         state = self.TruncationState(inner_state=inner_state, steps=0)
-        return state, info.update(truncated=self.max_steps <= 0)
+        return state, info
 
     @override
-    def reset(self, state: WrappedState, key: Key) -> tuple[WrappedState, Info]:
+    def reset(self, state: TruncationState, key: Key) -> tuple[TruncationState, Info]:
         inner_state, info = self.env.reset(state.inner_state, key)
         state = state.replace(inner_state=inner_state, steps=0)
-        return state, info.update(truncated=self.max_steps <= 0)
+        return state, info
 
     @override
-    def step(self, state: WrappedState, action: PyTree) -> tuple[WrappedState, Info]:
+    def step(
+        self, state: TruncationState, action: PyTree
+    ) -> tuple[TruncationState, Info]:
         next_inner_state, info = self.env.step(state.inner_state, action)
         steps = state.steps + 1
         state = self.TruncationState(inner_state=next_inner_state, steps=steps)
-        truncated = jnp.asarray(steps) >= self.max_steps
+        truncated = jnp.asarray(info.truncated) | (jnp.asarray(steps) >= self.max_steps)
         return state, info.update(truncated=truncated)

--- a/src/envelope/wrappers/truncation_wrapper.py
+++ b/src/envelope/wrappers/truncation_wrapper.py
@@ -1,6 +1,7 @@
 from typing import override
 
 import jax.numpy as jnp
+from jax import core
 
 from envelope.environment import Info
 from envelope.struct import field
@@ -15,7 +16,7 @@ class TruncationWrapper(Wrapper):
         steps: jnp.ndarray | int = field(default=0)
 
     def __post_init__(self):
-        if self.max_steps <= 0:
+        if not isinstance(self.max_steps, core.Tracer) and self.max_steps <= 0:
             raise ValueError("max_steps must be greater than zero")
         super().__post_init__()
 

--- a/src/envelope/wrappers/vmap_envs_wrapper.py
+++ b/src/envelope/wrappers/vmap_envs_wrapper.py
@@ -8,10 +8,10 @@ from envelope import spaces
 from envelope.environment import Environment, Info
 from envelope.struct import field
 from envelope.typing import Key, PyTree
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import VectorizingWrapper, WrappedState, Wrapper
 
 
-class VmapEnvsWrapper(Wrapper):
+class VmapEnvsWrapper(Wrapper, VectorizingWrapper):
     """
     Vectorizes over a batched collection of environment instances (vmapping over 'self').
 
@@ -58,22 +58,22 @@ class VmapEnvsWrapper(Wrapper):
         )
         return next_state, info
 
+    @cached_property
     @override
-    @property
     def observation_space(self) -> spaces.Space:
         env0 = _index_env(self.env, 0, self.batch_size)
         return spaces.BatchedSpace(
             space=env0.observation_space, batch_size=self.batch_size
         )
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> spaces.Space:
         env0 = _index_env(self.env, 0, self.batch_size)
         return spaces.BatchedSpace(space=env0.action_space, batch_size=self.batch_size)
 
-    @override
     @property
+    @override
     def unwrapped(self) -> Environment:
         return self.env.unwrapped
 

--- a/src/envelope/wrappers/vmap_wrapper.py
+++ b/src/envelope/wrappers/vmap_wrapper.py
@@ -8,7 +8,7 @@ from envelope import spaces
 from envelope.environment import Info
 from envelope.struct import static_field
 from envelope.typing import Key, PyTree
-from envelope.wrappers.wrapper import WrappedState, Wrapper
+from envelope.wrappers.wrapper import VectorizingWrapper, WrappedState, Wrapper
 
 
 def is_single_key(key):
@@ -29,7 +29,7 @@ def _split_or_keep_key(key: Key, batch_size: int) -> Key:
     )
 
 
-class VmapWrapper(Wrapper):
+class VmapWrapper(Wrapper, VectorizingWrapper):
     """Does not wrap the state."""
 
     batch_size: int = static_field(kw_only=True)
@@ -51,15 +51,15 @@ class VmapWrapper(Wrapper):
         state, info = jax.vmap(self.env.step)(state, action)
         return state, info
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> spaces.Space:
         return spaces.BatchedSpace(
             space=self.env.observation_space, batch_size=self.batch_size
         )
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> spaces.Space:
         return spaces.BatchedSpace(
             space=self.env.action_space, batch_size=self.batch_size

--- a/src/envelope/wrappers/wrapper.py
+++ b/src/envelope/wrappers/wrapper.py
@@ -119,8 +119,7 @@ def _validate_stack(root: Environment) -> None:
                         f"{type(candidate).__name__}"
                     )
                 raise ValueError(
-                    f"{type(owner).__name__} cannot contain "
-                    f"{type(candidate).__name__}"
+                    f"{type(owner).__name__} cannot contain {type(candidate).__name__}"
                 )
 
 

--- a/src/envelope/wrappers/wrapper.py
+++ b/src/envelope/wrappers/wrapper.py
@@ -1,9 +1,16 @@
 from dataclasses import KW_ONLY
 from functools import cached_property
-from typing import override
+from typing import Any, override
 
 from envelope import spaces
-from envelope.environment import Environment, Info, State
+from envelope.environment import (
+    Environment,
+    Info,
+    StackConstraint,
+    State,
+    not_containing,
+    not_inside,
+)
 from envelope.struct import FrozenPyTreeNode, field
 from envelope.typing import Key, PyTree
 
@@ -19,10 +26,27 @@ class WrappedState(FrozenPyTreeNode):
         return self.inner_state
 
 
+class VectorizingWrapper:
+    """Marker mixin for wrappers that introduce a vectorized environment."""
+
+
+class PooledInitializationWrapper:
+    """Marker mixin for wrappers that replace resets with pooled init results."""
+
+
 class Wrapper(Environment):
-    """Wrapper for environments."""
+    """Base class for environments that delegate to another environment.
+
+    Environments and wrappers may declare directional ``stack_constraints`` using
+    ``not_inside`` and ``not_containing``. Construction validates the complete stack,
+    so constraints also apply through unrelated intermediate wrappers.
+    """
 
     env: Environment = field()
+
+    def __post_init__(self):
+        _validate_stack(self)
+        super().__post_init__()
 
     @override
     def init(self, key: Key) -> tuple[State, Info]:
@@ -36,22 +60,85 @@ class Wrapper(Environment):
     def step(self, state: State, action: PyTree) -> tuple[State, Info]:
         return self.env.step(state, action)
 
-    @override
     @cached_property
+    @override
     def observation_space(self) -> spaces.Space:
         return self.env.observation_space
 
-    @override
     @cached_property
+    @override
     def action_space(self) -> spaces.Space:
         return self.env.action_space
 
-    @override
     @property
+    @override
     def unwrapped(self) -> Environment:
         return self.env.unwrapped
 
-    def __getattr__(self, name):
-        if name == "__setstate__":
-            raise AttributeError(name)
-        return getattr(self.env, name)
+    @property
+    @override
+    def default_max_steps(self) -> int | None:
+        return self.env.default_max_steps
+
+    def __getattribute__(self, name: str) -> Any:
+        """Forward genuinely missing attributes without hiding wrapper failures.
+
+        ``__getattr__`` is also invoked when a descriptor defined on the wrapper
+        raises ``AttributeError``.  Blind delegation in that situation masks the
+        original error and makes debugging wrapper properties needlessly hard.
+        Distinguish a genuinely absent attribute from a failing descriptor before
+        consulting the wrapped environment.
+        """
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            cls = object.__getattribute__(self, "__class__")
+            if any(name in ancestor.__dict__ for ancestor in cls.__mro__):
+                raise
+            if name == "__setstate__":
+                raise
+            env = object.__getattribute__(self, "env")
+            return getattr(env, name)
+
+
+def _validate_stack(root: Environment) -> None:
+    layers = list(_iter_stack(root))
+    for index, owner in enumerate(layers):
+        for constraint in getattr(owner, "stack_constraints", ()):
+            candidates = (
+                layers[:index]
+                if constraint.direction == "outer"
+                else layers[index + 1 :]
+            )
+            for candidate in candidates:
+                if not isinstance(candidate, constraint.environment_types):
+                    continue
+                if constraint.direction == "outer":
+                    raise ValueError(
+                        f"{type(owner).__name__} cannot be inside "
+                        f"{type(candidate).__name__}"
+                    )
+                raise ValueError(
+                    f"{type(owner).__name__} cannot contain "
+                    f"{type(candidate).__name__}"
+                )
+
+
+def _iter_stack(env: Environment):
+    current = env
+    while True:
+        yield current
+        if not isinstance(current, Wrapper):
+            return
+        current = current.env
+
+
+__all__ = [
+    "PooledInitializationWrapper",
+    "StackConstraint",
+    "VectorizingWrapper",
+    "WrappedState",
+    "Wrapper",
+    "not_containing",
+    "not_inside",
+]

--- a/tests/adapters/test_brax_envelope.py
+++ b/tests/adapters/test_brax_envelope.py
@@ -57,8 +57,8 @@ def test_brax_info_preserves_brax_fields_on_reset(brax_fast_env, prng_key):
 
     # Check extra Brax state fields are preserved
     # Brax state typically has: obs, reward, done, metrics, info
-    assert hasattr(info, "done")
-    assert hasattr(info, "metrics")
+    assert hasattr(info.backend, "done")
+    assert hasattr(info.backend, "metrics")
 
     # Verify state fields match what was returned
     assert state is not None
@@ -72,18 +72,11 @@ def test_brax_terminated_matches_done_on_step(brax_fast_env, prng_key):
     state, _info = env.init(key_reset)
     action = env.action_space.sample(key_action)
     _next_state, info = env.step(state, action)
-    assert hasattr(info, "done")
-    assert info.terminated == info.done
+    assert hasattr(info.backend, "done")
+    assert info.terminated == info.backend.done
 
 
-def test_from_name_with_auto_reset_error():
-    """Test that from_name raises ValueError when using auto_reset."""
-    with pytest.raises(ValueError, match="Cannot override 'auto_reset' directly"):
-        BraxEnvelope.from_name("fast", env_kwargs={"auto_reset": True})
-
-
-def test_wrapper_unwrapping():
-    """Test that wrapped Brax environments are properly unwrapped."""
+def test_pre_wrapped_brax_environment_is_preserved():
     from brax.envs import create as brax_create
 
     # Create a base Brax environment
@@ -99,15 +92,9 @@ def test_wrapper_unwrapping():
 
     wrapped_env = SimpleWrapper(base_env)
 
-    # Initialize BraxEnvelope with wrapped environment
-    with pytest.warns(
-        UserWarning, match="Environment wrapping should be handled by envelope"
-    ):
-        env = BraxEnvelope(brax_env=wrapped_env)
+    env = BraxEnvelope(brax_env=wrapped_env)
 
-    # Verify environment is properly unwrapped
-    assert not isinstance(env.brax_env, BraxWrapper)
-    assert env.brax_env is wrapped_env.unwrapped
+    assert env.brax_env is wrapped_env
 
 
 def test_deepcopy_warning(brax_fast_env, prng_key):

--- a/tests/adapters/test_brax_regressions.py
+++ b/tests/adapters/test_brax_regressions.py
@@ -1,0 +1,87 @@
+"""Focused Brax adapter regressions using a fake backend environment."""
+
+# ruff: noqa: E402
+
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+pytestmark = pytest.mark.adapters
+
+pytest.importorskip("brax")
+
+import envelope.adapters.brax_envelope as brax_envelope_module
+from envelope.adapters.brax_envelope import BraxEnvelope
+
+
+def test_from_name_disables_default_backend_limit(monkeypatch):
+    captured_kwargs = {}
+
+    monkeypatch.setattr(
+        brax_envelope_module,
+        "brax_create",
+        lambda _name, **kwargs: captured_kwargs.update(kwargs) or object(),
+    )
+
+    env = BraxEnvelope.from_name("fast")
+
+    assert captured_kwargs == {"episode_length": None, "auto_reset": False}
+    assert env.default_max_steps == 1000
+
+
+def test_from_name_adds_defaults_without_overriding_explicit_backend_controls(
+    monkeypatch,
+):
+    raw_env = object()
+    captured_kwargs = {}
+
+    def fake_brax_create(env_name, **kwargs):
+        assert env_name == "fast"
+        captured_kwargs.update(kwargs)
+        return raw_env
+
+    monkeypatch.setattr(brax_envelope_module, "brax_create", fake_brax_create)
+    caller_kwargs = {
+        "backend": "generalized",
+        "episode_length": 17,
+        "auto_reset": True,
+        "batch_size": 2,
+        "action_repeat": 2,
+    }
+
+    with pytest.warns(UserWarning, match="backend settings"):
+        env = BraxEnvelope.from_name("fast", env_kwargs=caller_kwargs)
+
+    assert env.brax_env is raw_env
+    assert captured_kwargs == caller_kwargs
+    assert env.default_max_steps == 17
+
+
+def test_done_is_cast_to_boolean_in_init_and_step():
+    class FakeBraxEnv:
+        def reset(self, key):
+            del key
+            return SimpleNamespace(
+                obs=jnp.asarray([0.0]),
+                reward=jnp.asarray(0.0),
+                done=jnp.asarray(0.0),
+            )
+
+        def step(self, state, action):
+            del state, action
+            return SimpleNamespace(
+                obs=jnp.asarray([1.0]),
+                reward=jnp.asarray(1.0),
+                done=jnp.asarray(1.0),
+            )
+
+    env = BraxEnvelope(brax_env=FakeBraxEnv())
+    state, initial = env.init(jax.random.key(0))
+    _, stepped = env.step(state, jnp.asarray(0.0))
+
+    assert initial.terminated.dtype == jnp.bool_
+    assert stepped.terminated.dtype == jnp.bool_
+    assert not bool(initial.terminated)
+    assert bool(stepped.terminated)

--- a/tests/adapters/test_common.py
+++ b/tests/adapters/test_common.py
@@ -1,0 +1,56 @@
+import warnings
+
+import pytest
+
+from envelope.adapters._common import _capture_horizon, warn_if_wrapper_overlap
+
+
+def test_warn_if_wrapper_overlap_reports_only_overlapping_arguments():
+    supplied_args = {
+        "safe_backend_option": True,
+        "episode_length": 17,
+        "auto_reset": False,
+    }
+
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r"Explicit Example backend settings may overlap with Envelope wrappers: "
+            r"auto_reset, episode_length\."
+        ),
+    ):
+        warn_if_wrapper_overlap(
+            "Example",
+            supplied_args,
+            ("episode_length", "auto_reset", "batch_size"),
+        )
+
+
+def test_warn_if_wrapper_overlap_ignores_unrelated_arguments():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_wrapper_overlap(
+            "Example", {"safe_backend_option": True}, ("auto_reset",)
+        )
+
+
+def test_warn_if_wrapper_overlap_handles_named_optional_arguments():
+    with pytest.warns(UserWarning, match=r"env_params\."):
+        warn_if_wrapper_overlap("Example", {}, ("env_params",), env_params=object())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_wrapper_overlap("Example", {}, ("env_params",), env_params=None)
+
+
+def test_warn_if_wrapper_overlap_accepts_none_supplied_args():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warn_if_wrapper_overlap("Example", None, ("auto_reset",))
+
+
+def test_capture_horizon_checks_finiteness_before_conversion():
+    assert _capture_horizon(17.9) == 17
+    assert _capture_horizon(None) is None
+    assert _capture_horizon(float("inf")) is None
+    assert _capture_horizon(float("-inf")) is None

--- a/tests/adapters/test_craftax_envelope.py
+++ b/tests/adapters/test_craftax_envelope.py
@@ -2,6 +2,8 @@
 
 # ruff: noqa: E402
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -10,16 +12,9 @@ pytestmark = pytest.mark.adapters
 
 pytest.importorskip("craftax")
 
-from craftax.craftax.envs.craftax_pixels_env import (
-    CraftaxPixelsEnv,
-    CraftaxPixelsEnvNoAutoReset,
-)
-from craftax.craftax_classic.envs.craftax_pixels_env import (
-    CraftaxClassicPixelsEnv,
-    CraftaxClassicPixelsEnvNoAutoReset,
-)
-
+from envelope.adapters import craftax_envelope
 from envelope.spaces import Continuous, Discrete
+from envelope.struct import Container
 from tests.contract import (
     assert_jitted_rollout_contract,
     assert_obs_matches_space,
@@ -64,17 +59,6 @@ def _one_step(env, state, key):
 
 
 def test_craftax_contract_smoke(craftax_env, prng_key):
-    failing_envs = (
-        CraftaxPixelsEnv,
-        CraftaxClassicPixelsEnv,
-        CraftaxPixelsEnvNoAutoReset,
-        CraftaxClassicPixelsEnvNoAutoReset,
-    )
-    if isinstance(craftax_env.craftax_env, failing_envs):
-        pytest.xfail(
-            "Craftax currently returns the wrong observation space. "
-            "See https://github.com/MichaelTMatthews/Craftax/pull/49"
-        )
     assert_reset_step_contract(
         craftax_env, key=prng_key, obs_check=assert_obs_matches_space
     )
@@ -120,8 +104,69 @@ class _DummyEnv:
         self.default_params = default_params
 
 
-def test_from_name_errors_on_auto_reset():
-    from envelope.adapters.craftax_envelope import CraftaxEnvelope
+def test_from_name_captures_default_before_disabling_time_limit(monkeypatch):
+    dummy_env = _DummyEnv(_DummyParams(max_timesteps=100))
+    monkeypatch.setattr(
+        craftax_envelope, "make_craftax_env_from_name", lambda *_args, **_kwargs: dummy_env
+    )
+    monkeypatch.setattr(
+        craftax_envelope,
+        "_probe_gymnaxlike_info_placeholder",
+        lambda _env, _params: Container(),
+    )
 
-    with pytest.raises(ValueError, match="Cannot override 'auto_reset' directly"):
-        CraftaxEnvelope.from_name("AnyEnv", env_kwargs={"auto_reset": True})
+    env = craftax_envelope.CraftaxEnvelope.from_name("AnyEnv")
+
+    assert jnp.isposinf(env.env_params.max_timesteps)
+    assert env.default_max_steps == 100
+
+
+def test_from_name_preserves_explicit_auto_reset(monkeypatch):
+    captured_kwargs = {}
+    dummy_env = _DummyEnv(_DummyParams(max_timesteps=100))
+
+    def make_env(_name, **kwargs):
+        captured_kwargs.update(kwargs)
+        return dummy_env
+
+    monkeypatch.setattr(craftax_envelope, "make_craftax_env_from_name", make_env)
+    monkeypatch.setattr(
+        craftax_envelope,
+        "_probe_gymnaxlike_info_placeholder",
+        lambda _env, _params: Container(),
+    )
+
+    supplied_params = _DummyParams(max_timesteps=17)
+    with pytest.warns(UserWarning, match="backend settings"):
+        env = craftax_envelope.CraftaxEnvelope.from_name(
+            "AnyEnv",
+            env_params=supplied_params,
+            env_kwargs={"auto_reset": True},
+        )
+
+    assert captured_kwargs["auto_reset"] is True
+    assert env.craftax_env is dummy_env
+    assert env.env_params is supplied_params
+    assert env.default_max_steps == 17
+
+
+def test_from_name_preserves_nonfinite_explicit_horizon_without_warning(monkeypatch):
+    dummy_env = _DummyEnv(_DummyParams(max_timesteps=100))
+    monkeypatch.setattr(
+        craftax_envelope, "make_craftax_env_from_name", lambda *_args, **_kwargs: dummy_env
+    )
+    monkeypatch.setattr(
+        craftax_envelope,
+        "_probe_gymnaxlike_info_placeholder",
+        lambda _env, _params: Container(),
+    )
+    supplied_params = _DummyParams(max_timesteps=jnp.inf)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        env = craftax_envelope.CraftaxEnvelope.from_name(
+            "AnyEnv", env_params=supplied_params
+        )
+
+    assert env.env_params is supplied_params
+    assert env.default_max_steps is None

--- a/tests/adapters/test_craftax_envelope.py
+++ b/tests/adapters/test_craftax_envelope.py
@@ -107,7 +107,9 @@ class _DummyEnv:
 def test_from_name_captures_default_before_disabling_time_limit(monkeypatch):
     dummy_env = _DummyEnv(_DummyParams(max_timesteps=100))
     monkeypatch.setattr(
-        craftax_envelope, "make_craftax_env_from_name", lambda *_args, **_kwargs: dummy_env
+        craftax_envelope,
+        "make_craftax_env_from_name",
+        lambda *_args, **_kwargs: dummy_env,
     )
     monkeypatch.setattr(
         craftax_envelope,
@@ -153,7 +155,9 @@ def test_from_name_preserves_explicit_auto_reset(monkeypatch):
 def test_from_name_preserves_nonfinite_explicit_horizon_without_warning(monkeypatch):
     dummy_env = _DummyEnv(_DummyParams(max_timesteps=100))
     monkeypatch.setattr(
-        craftax_envelope, "make_craftax_env_from_name", lambda *_args, **_kwargs: dummy_env
+        craftax_envelope,
+        "make_craftax_env_from_name",
+        lambda *_args, **_kwargs: dummy_env,
     )
     monkeypatch.setattr(
         craftax_envelope,

--- a/tests/adapters/test_create.py
+++ b/tests/adapters/test_create.py
@@ -8,12 +8,63 @@ These tests are dependency-free (no brax/gymnax/navix imports) and focus on:
 """
 
 import importlib
+import inspect
 import types
+from functools import cached_property
+from typing import Literal, get_type_hints
 
+import jax
+import jax.numpy as jnp
 import pytest
 
 import envelope.adapters as adapters
 from envelope.adapters import create
+from envelope.environment import Environment, InfoContainer
+from envelope.spaces import Discrete
+from envelope.struct import Container
+from envelope.wrappers.truncation_wrapper import TruncationWrapper
+
+
+class _FakeAdapter(Environment):
+    """Dependency-free adapter used to exercise factory/wrapper semantics."""
+
+    default_max_steps: int | None = None
+
+    @cached_property
+    def observation_space(self) -> Discrete:
+        return Discrete(n=100)
+
+    @cached_property
+    def action_space(self) -> Discrete:
+        return Discrete(n=2)
+
+    def _info(self, state: jax.Array, *, reward: float) -> InfoContainer:
+        return InfoContainer(
+            obs=state,
+            reward=reward,
+            terminated=False,
+            truncated=False,
+        ).update(backend=Container().update(step=state))
+
+    def init(self, key: jax.Array):
+        del key
+        state = jnp.asarray(0, dtype=jnp.int32)
+        return state, self._info(state, reward=0.0)
+
+    def step(self, state: jax.Array, action: jax.Array):
+        del action
+        state = state + 1
+        return state, self._info(state, reward=1.0)
+
+
+def test_create_public_max_episode_steps_signature():
+    parameter = inspect.signature(create).parameters["max_episode_steps"]
+
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default == "default"
+    assert get_type_hints(create)["max_episode_steps"] == (
+        Literal["default"] | int | None
+    )
 
 
 def _install_dummy_suite(
@@ -37,12 +88,13 @@ def _install_dummy_suite(
             return return_value
 
     dummy_module = types.SimpleNamespace(**{class_name: DummyWrapper})
+    real_import_module = importlib.import_module
 
     def fake_import_module(name: str):
-        import_calls.append(name)
-        if name != module_name:
-            raise AssertionError(f"Unexpected import: {name}")
-        return dummy_module
+        if name == module_name:
+            import_calls.append(name)
+            return dummy_module
+        return real_import_module(name)
 
     monkeypatch.setattr(adapters, "_env_module_map", {suite: (module_name, class_name)})
     monkeypatch.setattr(importlib, "import_module", fake_import_module)
@@ -104,9 +156,95 @@ def test_create_wraps_import_error_and_chains_cause(monkeypatch):
 
     msg = str(excinfo.value)
     assert "Failed to import dummy wrapper" in msg
-    assert "Make sure you have installed the 'dummy' dependencies" in msg
+    assert "Make sure the 'dummy' library is installed" in msg
     assert excinfo.value.__cause__ is not None
     assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+@pytest.mark.parametrize(
+    ("suite", "module_name", "class_name", "env_name", "dependency"),
+    [
+        (
+            "brax",
+            "envelope.adapters.brax_envelope",
+            "BraxEnvelope",
+            "fast",
+            "brax",
+        ),
+        (
+            "craftax",
+            "envelope.adapters.craftax_envelope",
+            "CraftaxEnvelope",
+            "Craftax-Symbolic-v1",
+            "craftax",
+        ),
+        (
+            "gymnax",
+            "envelope.adapters.gymnax_envelope",
+            "GymnaxEnvelope",
+            "CartPole-v1",
+            "gymnax",
+        ),
+        (
+            "jumanji",
+            "envelope.adapters.jumanji_envelope",
+            "JumanjiEnvelope",
+            "Snake-v1",
+            "jumanji",
+        ),
+        (
+            "kinetix",
+            "envelope.adapters.kinetix_envelope",
+            "KinetixEnvelope",
+            "random",
+            "kinetix",
+        ),
+        (
+            "mujoco_playground",
+            "envelope.adapters.mujoco_playground_envelope",
+            "MujocoPlaygroundEnvelope",
+            "CartpoleBalance",
+            "mujoco_playground",
+        ),
+        (
+            "navix",
+            "envelope.adapters.navix_envelope",
+            "NavixEnvelope",
+            "Navix-Empty-5x5-v0",
+            "navix",
+        ),
+    ],
+)
+def test_create_import_error_includes_exact_install_command(
+    monkeypatch,
+    suite,
+    module_name,
+    class_name,
+    env_name,
+    dependency,
+):
+    monkeypatch.setattr(
+        adapters,
+        "_env_module_map",
+        {suite: (module_name, class_name)},
+    )
+
+    missing = ModuleNotFoundError(f"No module named '{dependency}'", name=dependency)
+
+    def fake_import_module(name: str):
+        assert name == module_name
+        raise missing
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError) as excinfo:
+        create(f"{suite}::{env_name}")
+
+    msg = str(excinfo.value)
+    assert f"Make sure the '{suite}' library is installed" in msg
+    assert "pip install" not in msg
+    assert "git+" not in msg
+    assert excinfo.value.__cause__ is missing
 
 
 def test_create_forwards_env_name_env_kwargs_and_kwargs(monkeypatch):
@@ -116,7 +254,9 @@ def test_create_forwards_env_name_env_kwargs_and_kwargs(monkeypatch):
     )
 
     env_kwargs = {"a": 1}
-    out = create("dummy::MyEnv", env_kwargs=env_kwargs, foo=2)
+    out = create(
+        "dummy::MyEnv", env_kwargs=env_kwargs, max_episode_steps=None, foo=2
+    )
 
     assert out is sentinel
     assert import_calls == ["dummy_mod"]
@@ -130,12 +270,41 @@ def test_create_preserves_env_kwargs_none_vs_empty_dict(monkeypatch):
         monkeypatch, return_value=None
     )
 
-    create("dummy::A")
+    create("dummy::A", max_episode_steps=None)
     assert from_name_calls[-1]["env_kwargs"] is None
 
     empty: dict[str, object] = {}
-    create("dummy::B", env_kwargs=empty)
+    create("dummy::B", env_kwargs=empty, max_episode_steps=None)
     assert from_name_calls[-1]["env_kwargs"] is empty
+
+
+def test_create_passes_caller_env_kwargs_directly(monkeypatch):
+    sentinel = object()
+    received: list[dict[str, object]] = []
+
+    class MutatingWrapper:
+        @classmethod
+        def from_name(cls, env_name: str, env_kwargs=None, **kwargs):
+            del env_name, kwargs
+            assert env_kwargs is not None
+            received.append(env_kwargs)
+            env_kwargs["adapter_internal"] = True
+            return sentinel
+
+    module = types.SimpleNamespace(MutatingWrapper=MutatingWrapper)
+    monkeypatch.setattr(
+        adapters,
+        "_env_module_map",
+        {"dummy": ("dummy_mod", "MutatingWrapper")},
+    )
+    monkeypatch.setattr(importlib, "import_module", lambda _: module)
+
+    env_kwargs: dict[str, object] = {"user_value": 3}
+    out = create("dummy::Env", env_kwargs=env_kwargs, max_episode_steps=None)
+
+    assert out is sentinel
+    assert received[0] is env_kwargs
+    assert received[0] == {"user_value": 3, "adapter_internal": True}
 
 
 def test_create_splits_only_on_first_separator(monkeypatch):
@@ -143,7 +312,7 @@ def test_create_splits_only_on_first_separator(monkeypatch):
         monkeypatch, return_value=None
     )
 
-    create("dummy::::ant")
+    create("dummy::::ant", max_episode_steps=None)
     assert from_name_calls == [{"env_name": "::ant", "env_kwargs": None, "kwargs": {}}]
 
 
@@ -179,17 +348,161 @@ def test_create_imports_only_the_requested_suite(monkeypatch):
 
     monkeypatch.setattr(importlib, "import_module", fake_import_module)
 
-    assert create("a::Env") == "A"
+    assert create("a::Env", max_episode_steps=None) == "A"
     assert import_calls == ["a_mod"]
 
 
 def test_create_wraps_with_truncation_when_default_max_steps_set(monkeypatch):
-    sentinel = types.SimpleNamespace(default_max_steps=500)
-    _install_dummy_suite(monkeypatch, return_value=sentinel)
+    adapter = _FakeAdapter(default_max_steps=500)
+    _install_dummy_suite(monkeypatch, return_value=adapter)
 
     env = create("dummy::Env")
 
-    from envelope.wrappers.truncation_wrapper import TruncationWrapper
-
     assert isinstance(env, TruncationWrapper)
     assert env.max_steps == 500
+
+
+def test_create_omitted_max_episode_steps_uses_captured_adapter_horizon(monkeypatch):
+    adapter = _FakeAdapter(default_max_steps=2)
+    _install_dummy_suite(monkeypatch, return_value=adapter)
+
+    env = create("dummy::Env")
+
+    assert isinstance(env, TruncationWrapper)
+    assert env.max_steps == 2
+
+    state, init_info = env.init(jax.random.key(0))
+    state, first_info = env.step(state, jnp.asarray(0))
+    _state, second_info = env.step(state, jnp.asarray(0))
+
+    assert not bool(first_info.truncated)
+    assert bool(second_info.truncated)
+    assert int(init_info.backend.step) == 0
+    assert int(first_info.backend.step) == 1
+    assert int(second_info.backend.step) == 2
+    assert jax.tree.structure(init_info.backend) == jax.tree.structure(
+        first_info.backend
+    )
+    assert jax.tree.structure(first_info.backend) == jax.tree.structure(
+        second_info.backend
+    )
+
+
+def test_create_explicit_default_uses_captured_adapter_horizon(monkeypatch):
+    adapter = _FakeAdapter(default_max_steps=9)
+    _import_calls, from_name_calls = _install_dummy_suite(
+        monkeypatch, return_value=adapter
+    )
+
+    env = create("dummy::Env", max_episode_steps="default")
+
+    assert isinstance(env, TruncationWrapper)
+    assert env.max_steps == 9
+    assert from_name_calls == [{"env_name": "Env", "env_kwargs": None, "kwargs": {}}]
+
+
+@pytest.mark.parametrize("max_episode_steps", [1, 7, 100])
+def test_create_explicit_max_episode_steps_overrides_captured_horizon(
+    monkeypatch, max_episode_steps
+):
+    adapter = _FakeAdapter(default_max_steps=500)
+    _import_calls, from_name_calls = _install_dummy_suite(
+        monkeypatch, return_value=adapter
+    )
+
+    env = create("dummy::Env", max_episode_steps=max_episode_steps)
+
+    assert isinstance(env, TruncationWrapper)
+    assert env.max_steps == max_episode_steps
+    assert from_name_calls == [{"env_name": "Env", "env_kwargs": None, "kwargs": {}}]
+
+
+def test_create_explicit_max_episode_steps_works_without_adapter_default(monkeypatch):
+    adapter = _FakeAdapter(default_max_steps=None)
+    _install_dummy_suite(monkeypatch, return_value=adapter)
+
+    env = create("dummy::Env", max_episode_steps=3)
+
+    assert isinstance(env, TruncationWrapper)
+    assert env.max_steps == 3
+
+
+def test_create_explicit_none_disables_captured_horizon(monkeypatch):
+    adapter = _FakeAdapter(default_max_steps=500)
+    _import_calls, from_name_calls = _install_dummy_suite(
+        monkeypatch, return_value=adapter
+    )
+
+    env = create("dummy::Env", max_episode_steps=None)
+
+    assert env is adapter
+    assert from_name_calls == [{"env_name": "Env", "env_kwargs": None, "kwargs": {}}]
+
+
+@pytest.mark.parametrize("max_episode_steps", [True, 1.5])
+def test_create_accepts_runnable_non_integer_max_episode_steps(
+    monkeypatch, max_episode_steps
+):
+    _import_calls, _from_name_calls = _install_dummy_suite(
+        monkeypatch, return_value=_FakeAdapter(default_max_steps=500)
+    )
+
+    env = create("dummy::Env", max_episode_steps=max_episode_steps)
+
+    assert isinstance(env, TruncationWrapper)
+    assert env.max_steps == max_episode_steps
+
+
+@pytest.mark.parametrize("max_episode_steps", [False, 0, -1])
+def test_truncation_rejects_non_positive_factory_horizons(
+    monkeypatch, max_episode_steps
+):
+    import_calls, _from_name_calls = _install_dummy_suite(
+        monkeypatch, return_value=_FakeAdapter(default_max_steps=500)
+    )
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        create("dummy::Env", max_episode_steps=max_episode_steps)
+    assert import_calls == ["dummy_mod"]
+
+
+@pytest.mark.parametrize("captured_horizon", [True, 1.5])
+def test_create_accepts_runnable_non_integer_captured_adapter_horizon(
+    monkeypatch, captured_horizon
+):
+    _install_dummy_suite(
+        monkeypatch, return_value=_FakeAdapter(default_max_steps=captured_horizon)
+    )
+
+    env = create("dummy::Env")
+
+    assert isinstance(env, TruncationWrapper)
+    assert env.max_steps == captured_horizon
+
+
+@pytest.mark.parametrize("captured_horizon", [False, 0, -1])
+def test_truncation_rejects_non_positive_captured_adapter_horizon(
+    monkeypatch, captured_horizon
+):
+    _install_dummy_suite(
+        monkeypatch, return_value=_FakeAdapter(default_max_steps=captured_horizon)
+    )
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        create("dummy::Env")
+
+
+@pytest.mark.parametrize("max_episode_steps", [None, 3])
+def test_explicit_max_episode_steps_takes_precedence_over_invalid_adapter_default(
+    monkeypatch, max_episode_steps
+):
+    adapter = _FakeAdapter(default_max_steps=0)
+    _install_dummy_suite(monkeypatch, return_value=adapter)
+
+    env = create("dummy::Env", max_episode_steps=max_episode_steps)
+
+    if max_episode_steps is None:
+        assert env is adapter
+    else:
+        assert isinstance(env, TruncationWrapper)
+        assert env.max_steps == max_episode_steps

--- a/tests/adapters/test_create.py
+++ b/tests/adapters/test_create.py
@@ -254,9 +254,7 @@ def test_create_forwards_env_name_env_kwargs_and_kwargs(monkeypatch):
     )
 
     env_kwargs = {"a": 1}
-    out = create(
-        "dummy::MyEnv", env_kwargs=env_kwargs, max_episode_steps=None, foo=2
-    )
+    out = create("dummy::MyEnv", env_kwargs=env_kwargs, max_episode_steps=None, foo=2)
 
     assert out is sentinel
     assert import_calls == ["dummy_mod"]

--- a/tests/adapters/test_create_integration.py
+++ b/tests/adapters/test_create_integration.py
@@ -13,6 +13,14 @@ from envelope.wrappers.truncation_wrapper import TruncationWrapper
 pytestmark = pytest.mark.adapters
 
 
+def _run_init_and_step(env: Environment, key) -> None:
+    state, info = env.init(key)
+    assert hasattr(info, "obs")
+    action = env.action_space.sample(key)
+    _state, info = env.step(state, action)
+    assert hasattr(info, "obs")
+
+
 def test_create_brax_smoke(prng_key):
     pytest.importorskip("brax")
 
@@ -24,8 +32,7 @@ def test_create_brax_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 1000  # Brax default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
+    _run_init_and_step(env, prng_key)
 
 
 def test_create_gymnax_smoke(prng_key):
@@ -39,8 +46,7 @@ def test_create_gymnax_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 500  # CartPole-v1 default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
+    _run_init_and_step(env, prng_key)
 
 
 def test_create_navix_smoke(prng_key):
@@ -54,8 +60,7 @@ def test_create_navix_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 100  # Navix default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
+    _run_init_and_step(env, prng_key)
 
 
 def test_create_jumanji_smoke(prng_key):
@@ -69,8 +74,7 @@ def test_create_jumanji_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 4000  # Snake-v1 default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
+    _run_init_and_step(env, prng_key)
 
 
 def test_create_craftax_smoke(prng_key):
@@ -84,8 +88,7 @@ def test_create_craftax_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 100000  # Craftax default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
+    _run_init_and_step(env, prng_key)
 
 
 def test_create_mujoco_playground_smoke(prng_key):
@@ -99,8 +102,7 @@ def test_create_mujoco_playground_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 1000  # CartpoleBalance default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
+    _run_init_and_step(env, prng_key)
 
 
 def test_create_kinetix_smoke(prng_key):
@@ -114,13 +116,4 @@ def test_create_kinetix_smoke(prng_key):
     assert isinstance(env, Environment)
     assert env.max_steps == 256  # Kinetix default
 
-    _state, info = env.init(prng_key)
-    assert hasattr(info, "obs")
-
-
-def test_create_rejects_max_steps_override():
-    """Test that create() raises ValueError when trying to override max_steps."""
-    pytest.importorskip("gymnax")
-
-    with pytest.raises(ValueError, match="Cannot override"):
-        create("gymnax::CartPole-v1", env_kwargs={"max_steps_in_episode": 100})
+    _run_init_and_step(env, prng_key)

--- a/tests/adapters/test_gymnax_regressions.py
+++ b/tests/adapters/test_gymnax_regressions.py
@@ -1,0 +1,221 @@
+"""Focused Gymnax adapter regressions using a fake backend environment.
+
+The Gymnax package is still an optional dependency, but these tests avoid creating or
+compiling a real environment.  They belong to the isolated adapters test job.
+"""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+pytestmark = pytest.mark.adapters
+
+pytest.importorskip("gymnax")
+
+import envelope.adapters.gymnax_envelope as gymnax_envelope_module
+from envelope.adapters.gymnax_envelope import GymnaxEnvelope
+from envelope.struct import Container
+
+
+class _Params:
+    def __init__(self, max_steps_in_episode):
+        self.max_steps_in_episode = max_steps_in_episode
+
+    def replace(self, **updates):
+        return _Params(updates.get("max_steps_in_episode", self.max_steps_in_episode))
+
+
+class _ActionSpace:
+    def sample(self, key):
+        del key
+        return jnp.asarray(0, dtype=jnp.int32)
+
+
+class _FakeGymnaxEnv:
+    def __init__(self, default_horizon: int = 500):
+        self.default_params = _Params(default_horizon)
+
+    def reset(self, key, params):
+        del key, params
+        return jnp.asarray([0.0]), jnp.asarray(0, dtype=jnp.int32)
+
+    def step_env(self, key, state, action, params):
+        del key, action, params
+        next_state = state + 1
+        obs = jnp.asarray([next_state], dtype=jnp.float32)
+        backend_info = Container().update(
+            score=jnp.asarray(next_state, dtype=jnp.float32)
+        )
+        return obs, next_state, jnp.asarray(1.0), jnp.asarray(False), backend_info
+
+    def action_space(self, params):
+        del params
+        return _ActionSpace()
+
+
+class _AutoResetGymnaxEnv(_FakeGymnaxEnv):
+    """Expose Gymnax's public auto-reset separately from its raw transition."""
+
+    def __init__(self):
+        super().__init__()
+        self.public_step_calls = 0
+        self.raw_step_calls = 0
+
+    def reset(self, key, params):
+        del key, params
+        return jnp.asarray([-1.0]), jnp.asarray(-1, dtype=jnp.int32)
+
+    def step_env(self, key, state, action, params):
+        del key, action, params
+        self.raw_step_calls += 1
+        next_state = state + 1
+        backend_info = Container().update(
+            score=jnp.asarray(next_state, dtype=jnp.float32)
+        )
+        return (
+            jnp.asarray([next_state], dtype=jnp.float32),
+            next_state,
+            jnp.asarray(1.0),
+            jnp.asarray(True),
+            backend_info,
+        )
+
+    def step(self, key, state, action, params):
+        self.public_step_calls += 1
+        _obs, _state, reward, done, backend_info = self.step_env(
+            key, state, action, params
+        )
+        reset_obs, reset_state = self.reset(key, params)
+        return reset_obs, reset_state, reward, done, backend_info
+
+
+def test_supplied_parameters_are_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_env = _FakeGymnaxEnv(default_horizon=500)
+    constructor_kwargs = []
+
+    def fake_create(env_name, **kwargs):
+        assert env_name == "Fake-v0"
+        constructor_kwargs.append(kwargs)
+        return fake_env, fake_env.default_params
+
+    monkeypatch.setattr(gymnax_envelope_module, "gymnax_create", fake_create)
+    supplied_params = _Params(max_steps_in_episode=17)
+    caller_kwargs = {"difficulty": "hard"}
+
+    with pytest.warns(UserWarning, match="env_params"):
+        env = GymnaxEnvelope.from_name(
+            "Fake-v0", env_params=supplied_params, env_kwargs=caller_kwargs
+        )
+
+    assert constructor_kwargs == [{"difficulty": "hard"}]
+    assert supplied_params.max_steps_in_episode == 17
+    assert env.env_params is supplied_params
+    assert env.env_params.max_steps_in_episode == 17
+    assert env.default_max_steps == 17
+
+
+def test_backend_info_namespace_is_stable_between_init_and_step(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_env = _FakeGymnaxEnv(default_horizon=23)
+    monkeypatch.setattr(
+        gymnax_envelope_module,
+        "gymnax_create",
+        lambda env_name, **kwargs: (fake_env, fake_env.default_params),
+    )
+    env = GymnaxEnvelope.from_name("Fake-v0")
+
+    assert jnp.isposinf(env.env_params.max_steps_in_episode)
+    assert env.default_max_steps == 23
+
+    state, init_info = env.init(jax.random.key(0))
+    _next_state, step_info = env.step(state, jnp.asarray(0, dtype=jnp.int32))
+
+    assert hasattr(init_info, "backend")
+    assert hasattr(step_info, "backend")
+    assert not bool(init_info.backend.valid)
+    assert bool(step_info.backend.valid)
+    assert float(init_info.backend.score) == 0.0
+    assert init_info.backend.score.shape == step_info.backend.score.shape
+    assert init_info.backend.score.dtype == step_info.backend.score.dtype
+    assert jax.tree.structure(init_info.backend) == jax.tree.structure(
+        step_info.backend
+    )
+    assert [x.shape for x in jax.tree.leaves(init_info.backend)] == [
+        x.shape for x in jax.tree.leaves(step_info.backend)
+    ]
+    assert [x.dtype for x in jax.tree.leaves(init_info.backend)] == [
+        x.dtype for x in jax.tree.leaves(step_info.backend)
+    ]
+
+
+def test_constructor_max_steps_kwarg_uses_gymnax_naturally_without_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_env = _FakeGymnaxEnv(default_horizon=500)
+
+    def fake_create(env_name, **kwargs):
+        assert env_name == "Fake-v0"
+        params = _Params(kwargs["max_steps_in_episode"])
+        return fake_env, params
+
+    monkeypatch.setattr(gymnax_envelope_module, "gymnax_create", fake_create)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        env = GymnaxEnvelope.from_name(
+            "Fake-v0", env_kwargs={"max_steps_in_episode": 31}
+        )
+
+    assert env.default_max_steps == 31
+    assert jnp.isposinf(env.env_params.max_steps_in_episode)
+
+
+def test_nonfinite_explicit_parameters_are_preserved_without_horizon_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_env = _FakeGymnaxEnv()
+    monkeypatch.setattr(
+        gymnax_envelope_module,
+        "gymnax_create",
+        lambda env_name, **kwargs: (fake_env, fake_env.default_params),
+    )
+    supplied_params = _Params(max_steps_in_episode=jnp.inf)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        env = GymnaxEnvelope.from_name("Fake-v0", env_params=supplied_params)
+
+    assert env.env_params is supplied_params
+    assert env.default_max_steps is None
+
+
+def test_step_bypasses_gymnax_public_auto_reset(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake_env = _AutoResetGymnaxEnv()
+    monkeypatch.setattr(
+        gymnax_envelope_module,
+        "gymnax_create",
+        lambda env_name, **kwargs: (fake_env, fake_env.default_params),
+    )
+    env = GymnaxEnvelope.from_name("Fake-v0")
+    fake_env.public_step_calls = 0
+    fake_env.raw_step_calls = 0
+
+    state, _ = env.init(jax.random.key(0))
+    state, info = env.step(state, jnp.asarray(0, dtype=jnp.int32))
+
+    assert fake_env.public_step_calls == 0
+    assert fake_env.raw_step_calls == 1
+    assert int(state.env_state) == 0
+    assert jnp.array_equal(info.obs, jnp.asarray([0.0]))
+    assert bool(info.terminated)

--- a/tests/adapters/test_jumanji_envelope.py
+++ b/tests/adapters/test_jumanji_envelope.py
@@ -108,6 +108,28 @@ def test_bounded_array_spec_conversion_broadcasts_bounds(prng_key):
     assert space.contains(sample)
 
 
+def test_discrete_integer_dtype_is_preserved():
+    spec = specs.DiscreteArray(num_values=7, dtype=np.int8, name="int8")
+
+    space = convert_jumanji_spec_to_envelope_space(spec)
+
+    assert space.dtype == jnp.dtype(jnp.int8)
+
+
+def test_boolean_observations_use_int8():
+    class DummyTimestep:
+        observation = jnp.asarray([True, False])
+        reward = 0.0
+        extras = {}
+
+        def last(self):
+            return False
+
+    info = jumanji_envelope.convert_jumanji_to_envelope_info(DummyTimestep())
+
+    assert info.obs.dtype == jnp.int8
+
+
 def test_array_spec_conversion_float_is_unbounded_box():
     """Float Array converts to Continuous(-inf, +inf)."""
     spec = specs.Array(shape=(2, 3), dtype=np.float32, name="a")
@@ -130,6 +152,35 @@ def test_deepcopy_warning(jumanji_env):
     with pytest.warns(RuntimeWarning, match="Trying to deepcopy"):
         copied = deepcopy(env)
     assert copied is not None
+
+
+def test_default_time_limit_is_captured_then_disabled(monkeypatch):
+    class DummyEnv:
+        time_limit = 100
+
+    monkeypatch.setattr(
+        jumanji_envelope, "jumanji_make", lambda *_args, **_kwargs: DummyEnv()
+    )
+
+    env = JumanjiEnvelope.from_name("Dummy-v0")
+
+    assert env.default_max_steps == 100
+    assert env.jumanji_env.time_limit == jumanji_envelope._MAX_INT
+
+
+def test_explicit_time_limit_warns(monkeypatch):
+    class DummyEnv:
+        time_limit = 17
+
+    monkeypatch.setattr(
+        jumanji_envelope, "jumanji_make", lambda *_args, **_kwargs: DummyEnv()
+    )
+
+    with pytest.warns(UserWarning, match="time_limit"):
+        env = JumanjiEnvelope.from_name("Dummy-v0", env_kwargs={"time_limit": 17})
+
+    assert env.default_max_steps == 17
+    assert env.jumanji_env.time_limit == 17
 
 
 def test_namedtuple_observation_preserved_for_info():

--- a/tests/adapters/test_kinetix_envelope.py
+++ b/tests/adapters/test_kinetix_envelope.py
@@ -201,9 +201,7 @@ def test_from_name_dispatches_size_categories(
         KinetixEnvelope, "create_from_size", classmethod(create_from_size)
     )
 
-    result = KinetixEnvelope.from_name(
-        size, env_kwargs={"auto_reset": True}
-    )
+    result = KinetixEnvelope.from_name(size, env_kwargs={"auto_reset": True})
 
     assert result is sentinel
     assert calls == [(size, {"env_params": None, "auto_reset": True})]

--- a/tests/adapters/test_kinetix_envelope.py
+++ b/tests/adapters/test_kinetix_envelope.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import pathlib
+import warnings
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -12,9 +15,13 @@ pytestmark = pytest.mark.adapters
 
 pytest.importorskip("kinetix")
 
-from envelope.adapters.kinetix_envelope import KinetixEnvelope
+import kinetix
+from kinetix.environment import EnvParams, StaticEnvParams
+
+from envelope.adapters.kinetix_envelope import KinetixEnvelope, _normalize_level_id
 from envelope.environment import Info
 from envelope.spaces import Continuous
+from envelope.struct import Container
 from tests.contract import (
     assert_jitted_rollout_contract,
     assert_obs_matches_space,
@@ -48,11 +55,59 @@ def kinetix_random_env_warmup(kinetix_random_env, prng_key):
     jax.lax.scan(step_fn, state, actions)
 
 
-def _create_kinetix_env(name: str = "random", **kwargs):
+def _create_kinetix_env(level_id: str = "random", **kwargs):
     """Helper to create a KinetixEnvelope wrapper."""
-    if name == "random":
+    if level_id == "random":
         return KinetixEnvelope.create_random(**kwargs)
-    return KinetixEnvelope.create_from_size(name, **kwargs)
+    return KinetixEnvelope.from_name(level_id, env_kwargs=kwargs)
+
+
+def test_normalize_level_id_appends_json():
+    assert _normalize_level_id("s/h4_thrust_aim") == "s/h4_thrust_aim.json"
+
+
+def test_normalize_level_id_keeps_json():
+    assert _normalize_level_id("s/h4_thrust_aim.json") == "s/h4_thrust_aim.json"
+
+
+def test_normalize_level_id_strips_leading_slash_and_whitespace():
+    assert _normalize_level_id(" /s/h4_thrust_aim  ") == "s/h4_thrust_aim.json"
+
+
+@pytest.mark.parametrize("level_id", ["", "   "])
+def test_normalize_level_id_rejects_empty_values(level_id):
+    with pytest.raises(ValueError, match="non-empty"):
+        _normalize_level_id(level_id)
+
+
+def test_normalize_level_id_rejects_trailing_slash():
+    with pytest.raises(ValueError, match="must not end"):
+        _normalize_level_id("s/")
+
+
+def _first_packaged_level_id(size: str = "s") -> str:
+    """Return a packaged `{size}/{name}` level id, or skip if unavailable."""
+    pkg_dir = pathlib.Path(kinetix.__file__).resolve().parent
+    levels_dir = pkg_dir / "levels" / size
+    if not levels_dir.exists():
+        pytest.skip("kinetix package does not contain levels directory")
+    jsons = sorted(levels_dir.glob("*.json"))
+    if not jsons:
+        pytest.skip("kinetix package has no packaged JSON levels")
+    return f"{size}/{jsons[0].stem}"
+
+
+def _packaged_level_ids(sizes: tuple[str, ...] = ("s", "m", "l")) -> list[str]:
+    """Return all packaged `{size}/{name}` level ids."""
+    pkg_dir = pathlib.Path(kinetix.__file__).resolve().parent
+    out: list[str] = []
+    for size in sizes:
+        levels_dir = pkg_dir / "levels" / size
+        if not levels_dir.exists():
+            continue
+        for p in sorted(levels_dir.glob("*.json")):
+            out.append(f"{size}/{p.stem}")
+    return out
 
 
 def test_kinetix_contract_smoke(prng_key, kinetix_random_env):
@@ -72,9 +127,9 @@ def test_action_space_is_continuous_by_default(kinetix_random_env):
     assert isinstance(env.action_space, Continuous)
 
 
-@pytest.mark.parametrize("size", ["s", "m", "l"])
-def test_create_from_size_smoke(prng_key, size):
-    env = KinetixEnvelope.create_from_size(size)
+def test_from_name_premade_level_smoke(prng_key):
+    level_id = _first_packaged_level_id("s")
+    env = _create_kinetix_env(level_id)
 
     state, info = env.init(prng_key)
     assert state is not None
@@ -82,16 +137,11 @@ def test_create_from_size_smoke(prng_key, size):
     assert env.observation_space.contains(info.obs)
 
 
-def test_create_random_with_auto_reset_warning(prng_key):
-    with pytest.warns(
-        UserWarning,
-        match="Creating a KinetixEnvelope with auto_reset=True is not recommended",
-    ):
+def test_create_random_allows_auto_reset():
+    with pytest.warns(UserWarning, match="auto_reset"):
         env = _create_kinetix_env("random", auto_reset=True)
 
-    state, info = env.init(prng_key)
-    assert state is not None
-    assert isinstance(info, Info)
+    assert env is not None
 
 
 def test_key_splitting(kinetix_random_env, prng_key):
@@ -106,29 +156,148 @@ def test_key_splitting(kinetix_random_env, prng_key):
     assert not jnp.array_equal(next_state.key, state.key)
 
 
-def test_from_size_step_produces_finite_reward(prng_key):
-    """Test that stepping a size-based env produces finite rewards."""
-    env = KinetixEnvelope.create_from_size("s")
-    reset_key, action_key = jax.random.split(prng_key, 2)
+def test_random_premade_kinetix_envs(prng_key):
+    """Smoke-test a few packaged `{size}/{name}` levels (skip if none are packaged)."""
+    level_ids = _packaged_level_ids()
+    if not level_ids:
+        pytest.skip("kinetix package has no packaged JSON levels")
 
-    state, info = env.init(reset_key)
-    assert state is not None
-    assert isinstance(info, Info)
-    assert info.obs.shape == env.observation_space.shape
+    # Keep this deterministic and small (compile/runtime).
+    for level_id in level_ids[:3]:
+        env = _create_kinetix_env(level_id)
+        reset_key, action_key = jax.random.split(prng_key, 2)
 
-    action = env.action_space.sample(action_key)
-    next_state, next_info = env.step(state, action)
-    assert next_state is not None
-    assert isinstance(next_info, Info)
-    assert next_info.obs.shape == env.observation_space.shape
-    assert jnp.all(jnp.isfinite(jnp.asarray(next_info.reward)))
+        state, info = env.init(reset_key)
+        assert state is not None
+        assert isinstance(info, Info)
+        # Skip expensive contains check - shape/dtype check is sufficient
+        assert info.obs.shape == env.observation_space.shape
+
+        action = env.action_space.sample(action_key)
+        next_state, next_info = env.step(state, action)
+        assert next_state is not None
+        assert isinstance(next_info, Info)
+        assert next_info.obs.shape == env.observation_space.shape
+        assert jnp.all(jnp.isfinite(jnp.asarray(next_info.reward)))
 
 
 def test_from_name_rejects_unknown_env_kwargs():
     with pytest.raises(TypeError, match="unexpected keyword argument"):
-        KinetixEnvelope.from_name("s", env_kwargs={"unknown": 1})
+        KinetixEnvelope.from_name("s/h4_thrust_aim", env_kwargs={"unknown": 1})
 
 
-def test_from_name_rejects_invalid_name():
-    with pytest.raises(ValueError, match="Invalid env_name"):
+@pytest.mark.parametrize("size", ["s", "m", "l"])
+def test_from_name_dispatches_size_categories(
+    monkeypatch: pytest.MonkeyPatch, size: str
+):
+    sentinel = object()
+    calls = []
+
+    def create_from_size(cls, requested_size, **kwargs):
+        calls.append((requested_size, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(
+        KinetixEnvelope, "create_from_size", classmethod(create_from_size)
+    )
+
+    result = KinetixEnvelope.from_name(
+        size, env_kwargs={"auto_reset": True}
+    )
+
+    assert result is sentinel
+    assert calls == [(size, {"env_params": None, "auto_reset": True})]
+
+
+def test_create_random_preserves_explicit_finite_horizon_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from envelope.adapters import kinetix_envelope
+
+    supplied_params = EnvParams().replace(max_timesteps=17)
+    fake_env = object()
+    monkeypatch.setattr(
+        kinetix_envelope,
+        "make_reset_fn_sample_kinetix_level",
+        lambda *_args: object(),
+    )
+    monkeypatch.setattr(
+        kinetix_envelope,
+        "make_kinetix_env",
+        lambda **_kwargs: fake_env,
+    )
+    monkeypatch.setattr(
+        kinetix_envelope,
+        "_probe_gymnaxlike_info_placeholder",
+        lambda _env, _params: Container(),
+    )
+
+    with pytest.warns(UserWarning, match="reported as termination"):
+        env = KinetixEnvelope.create_random(env_params=supplied_params)
+
+    assert env.env_params is supplied_params
+    assert env.default_max_steps == 17
+
+
+def test_create_random_preserves_nonfinite_horizon_without_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from envelope.adapters import kinetix_envelope
+
+    supplied_params = EnvParams().replace(max_timesteps=jnp.inf)
+    monkeypatch.setattr(
+        kinetix_envelope,
+        "make_reset_fn_sample_kinetix_level",
+        lambda *_args: object(),
+    )
+    monkeypatch.setattr(
+        kinetix_envelope,
+        "make_kinetix_env",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        kinetix_envelope,
+        "_probe_gymnaxlike_info_placeholder",
+        lambda _env, _params: Container(),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        env = KinetixEnvelope.create_random(env_params=supplied_params)
+
+    assert env.env_params is supplied_params
+    assert env.default_max_steps is None
+
+
+def test_from_name_rejects_missing_premade_state(monkeypatch: pytest.MonkeyPatch):
+    from envelope.adapters import kinetix_envelope
+
+    def mock_load(_level_id: str):
+        return None, StaticEnvParams(), EnvParams()
+
+    monkeypatch.setattr(kinetix_envelope, "load_from_json_file", mock_load)
+    with pytest.raises(ValueError, match="did not contain a level state"):
         KinetixEnvelope.from_name("s/h4_thrust_aim")
+
+
+def test_create_premade_replace_failure_raises(monkeypatch: pytest.MonkeyPatch):
+    """Premade path does not guard against replace() failures."""
+    ep = EnvParams()
+    if not hasattr(ep, "max_timesteps") or not hasattr(ep, "replace"):
+        pytest.skip("Kinetix EnvParams does not expose max_timesteps/.replace")
+
+    def failing_replace(self, **kwargs):
+        raise AttributeError("replace failed")
+
+    monkeypatch.setattr(EnvParams, "replace", failing_replace)
+    monkeypatch.setattr(
+        "envelope.adapters.kinetix_envelope.load_from_json_file",
+        lambda _level_id: (object(), StaticEnvParams(), ep),
+    )
+
+    with pytest.raises(AttributeError, match="replace failed"):
+        KinetixEnvelope.from_name("s/h4_thrust_aim")
+
+
+# NOTE: Level-id normalization tests live in tests/adapters/test_kinetix_level_id.py
+# to keep this module focused on runtime wrapper behavior.

--- a/tests/adapters/test_mujoco_playground_envelope.py
+++ b/tests/adapters/test_mujoco_playground_envelope.py
@@ -2,6 +2,7 @@
 
 # ruff: noqa: E402
 
+import sys
 from types import SimpleNamespace
 
 import jax
@@ -235,3 +236,99 @@ def test_explicit_episode_length_is_passed_through(monkeypatch):
 
     assert captured["episode_length"] == 17
     assert env.default_max_steps == 17
+
+
+def test_default_warp_falls_back_to_jax_without_cuda(monkeypatch):
+    captured = {}
+    raw_env = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.get_default_config",
+        lambda _name: SimpleNamespace(episode_length=1000, impl="warp"),
+    )
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope._warp_cuda_available",
+        lambda: False,
+    )
+
+    def load(_name, *, config_overrides):
+        captured.update(config_overrides)
+        return raw_env
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.load", load
+    )
+
+    with pytest.warns(RuntimeWarning, match="falling back to the JAX"):
+        MujocoPlaygroundEnvelope.from_name("Fake")
+
+    assert captured["impl"] == "jax"
+
+
+def test_cuda_probe_failure_is_treated_as_unavailable(monkeypatch):
+    def fail_probe():
+        raise PermissionError("cache is not writable")
+
+    monkeypatch.setitem(
+        sys.modules, "warp", SimpleNamespace(is_cuda_available=fail_probe)
+    )
+
+    from envelope.adapters.mujoco_playground_envelope import _warp_cuda_available
+
+    assert not _warp_cuda_available()
+
+
+def test_default_warp_is_preserved_with_cuda(monkeypatch):
+    captured = {}
+    raw_env = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.get_default_config",
+        lambda _name: SimpleNamespace(episode_length=1000, impl="warp"),
+    )
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope._warp_cuda_available",
+        lambda: True,
+    )
+
+    def load(_name, *, config_overrides):
+        captured.update(config_overrides)
+        return raw_env
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.load", load
+    )
+
+    MujocoPlaygroundEnvelope.from_name("Fake")
+
+    assert "impl" not in captured
+
+
+def test_explicit_warp_is_preserved_without_cuda(monkeypatch):
+    captured = {}
+    raw_env = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.get_default_config",
+        lambda _name: SimpleNamespace(episode_length=1000, impl="warp"),
+    )
+
+    def unexpected_cuda_probe():
+        raise AssertionError("explicit implementations must not probe CUDA")
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope._warp_cuda_available",
+        unexpected_cuda_probe,
+    )
+
+    def load(_name, *, config_overrides):
+        captured.update(config_overrides)
+        return raw_env
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.load", load
+    )
+
+    MujocoPlaygroundEnvelope.from_name("Fake", env_kwargs={"impl": "warp"})
+
+    assert captured["impl"] == "warp"

--- a/tests/adapters/test_mujoco_playground_envelope.py
+++ b/tests/adapters/test_mujoco_playground_envelope.py
@@ -2,6 +2,8 @@
 
 # ruff: noqa: E402
 
+from types import SimpleNamespace
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -63,8 +65,8 @@ def test_mujoco_playground_terminated_matches_done_on_step(
     state, _info = env.init(key_reset)
     action = env.action_space.sample(key_action)
     _next_state, info = env.step(state, action)
-    assert hasattr(info, "done")
-    assert info.terminated == info.done
+    assert hasattr(info.backend, "done")
+    assert info.terminated == info.backend.done
     assert not info.truncated  # mujoco_playground doesn't distinguish truncation
 
 
@@ -207,3 +209,29 @@ def test_config_overrides_are_passed_correctly(prng_key):
 
     # Verify the config was applied
     assert env2.mujoco_playground_env.sim_dt == 0.005
+
+
+def test_explicit_episode_length_is_passed_through(monkeypatch):
+    captured = {}
+    raw_env = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.get_default_config",
+        lambda _name: SimpleNamespace(episode_length=1000),
+    )
+
+    def load(_name, *, config_overrides):
+        captured.update(config_overrides)
+        return raw_env
+
+    monkeypatch.setattr(
+        "envelope.adapters.mujoco_playground_envelope.registry.load", load
+    )
+
+    with pytest.warns(UserWarning, match="episode_length"):
+        env = MujocoPlaygroundEnvelope.from_name(
+            "Fake", env_kwargs={"episode_length": 17}
+        )
+
+    assert captured["episode_length"] == 17
+    assert env.default_max_steps == 17

--- a/tests/adapters/test_navix_envelope.py
+++ b/tests/adapters/test_navix_envelope.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.adapters
 pytest.importorskip("navix")
 
 import navix
+from navix.entities import EntityIds
 
 from envelope.adapters.navix_envelope import NavixEnvelope
 from envelope.spaces import Continuous, Discrete
@@ -41,7 +42,6 @@ def _navix_env_warmup(navix_env, prng_key):
     env.step(state, action)
 
 
-@pytest.mark.xfail(reason="navix obs space declares n=9 but env emits values >= 9")
 def test_navix_contract_smoke(prng_key, navix_env):
     assert_reset_step_contract(
         navix_env, key=prng_key, obs_check=assert_obs_matches_space
@@ -63,22 +63,28 @@ def test_action_space_conversion(navix_env):
     assert env.action_space.dtype == env.navix_env.action_space.dtype
 
 
-@pytest.mark.xfail(reason="navix obs space declares n=9 but env emits values >= 9")
-def test_observation_space_conversion(navix_env):
-    """Test conversion of navix observation spaces to envelope spaces."""
+def test_observation_space_contains_real_reset_observation(navix_env, prng_key):
+    """The converted cardinalities must include values emitted by Navix."""
     env = navix_env
-
-    # Check that observation space is converted correctly
     assert isinstance(env.observation_space, Discrete)
-    # Navix n might be scalar, envelope n is array - check if all elements equal navix n
-    navix_n = env.navix_env.observation_space.n
-    envelope_n = env.observation_space.n
-    if jnp.ndim(navix_n) == 0:  # scalar
-        assert jnp.all(envelope_n == navix_n)
-    else:
-        assert jnp.array_equal(envelope_n, navix_n)
+
+    _state, info = env.init(prng_key)
+
+    assert env.observation_space.contains(info.obs)
     assert env.observation_space.shape == env.navix_env.observation_space.shape
     assert env.observation_space.dtype == env.navix_env.observation_space.dtype
+
+
+def test_observation_entity_cardinality_comes_from_authoritative_ids(
+    navix_env, prng_key
+):
+    _state, info = navix_env.init(prng_key)
+    entity_cardinality = (
+        max(int(value) for name, value in vars(EntityIds).items() if name.isupper()) + 1
+    )
+
+    assert jnp.all(navix_env.observation_space.n[..., 0] == entity_cardinality)
+    assert jnp.all(info.obs[..., 0] < navix_env.observation_space.n[..., 0])
 
 
 def test_container_conversion_reset(navix_env, prng_key):
@@ -100,7 +106,7 @@ def test_container_conversion_reset(navix_env, prng_key):
     assert not info.terminated
     assert not info.truncated
 
-    # Check that extra timestep fields are preserved via update()
+    # Check that extra timestep fields are preserved at the top level.
     # (if navix timestep has extra fields beyond the standard ones)
     import dataclasses
 
@@ -136,7 +142,11 @@ def test_container_conversion_step(navix_env, prng_key):
 
 def test_episode_truncation(prng_key):
     """Test that episode truncation is correctly detected."""
-    env = _create_navix_env(max_steps=5)  # Very short episode
+    from envelope.wrappers.truncation_wrapper import TruncationWrapper
+
+    adapter = _create_navix_env(max_steps=5)
+    assert adapter.default_max_steps == 5
+    env = TruncationWrapper(env=adapter, max_steps=adapter.default_max_steps)
     key = prng_key
 
     state, info = env.init(key)
@@ -151,6 +161,24 @@ def test_episode_truncation(prng_key):
     # Verify truncation occurred
     assert info.truncated
     assert not info.terminated
+
+
+def test_explicit_max_steps_warns(monkeypatch):
+    from envelope.adapters import navix_envelope
+
+    class DummyEnv:
+        max_steps = 17
+
+    monkeypatch.setattr(
+        navix_envelope.navix, "make", lambda *_args, **_kwargs: DummyEnv()
+    )
+
+    with pytest.warns(UserWarning, match="max_steps"):
+        env = navix_envelope.NavixEnvelope.from_name(
+            "Dummy-v0", env_kwargs={"max_steps": 17}
+        )
+
+    assert env.default_max_steps == 17
 
 
 def test_unsupported_space_type():

--- a/tests/spaces/test_batched_space.py
+++ b/tests/spaces/test_batched_space.py
@@ -4,7 +4,14 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from envelope.spaces import BatchedSpace, Continuous, Discrete, PyTreeSpace
+from envelope.spaces import (
+    BatchedSpace,
+    Continuous,
+    Discrete,
+    PyTreeSpace,
+    peel_batched,
+    rebatch,
+)
 
 # ============================================================================
 # Tests: BatchedSpace - Basic Functionality
@@ -230,6 +237,20 @@ def test_batched_space_multiple_calls():
     assert sample.shape == (2, 3)
 
 
+def test_peel_batched_and_rebatch_round_trip():
+    base = Continuous.from_shape(low=-1.0, high=1.0, shape=(3,))
+    nested = BatchedSpace(
+        space=BatchedSpace(space=base, batch_size=5),
+        batch_size=2,
+    )
+
+    batch_dims, peeled = peel_batched(nested)
+
+    assert batch_dims == (2, 5)
+    assert peeled == base
+    assert rebatch(peeled, batch_dims) == nested
+
+
 def test_double_batched_pytree_space():
     """Test nested BatchedSpace wrapping a PyTreeSpace."""
     base_space = PyTreeSpace(
@@ -257,6 +278,10 @@ def test_double_batched_pytree_space():
 # ============================================================================
 # Tests: BatchedSpace - Edge Cases
 # ============================================================================
+
+
+def test_batched_space_defers_batch_size_validation():
+    BatchedSpace(space=Discrete(n=2), batch_size=0)
 
 
 def test_batched_space_batch_size_one():

--- a/tests/spaces/test_continuous.py
+++ b/tests/spaces/test_continuous.py
@@ -173,43 +173,20 @@ def test_continuous_tree_operations():
 # ============================================================================
 
 
-def test_continuous_space_validation():
-    """Test that Continuous space validates bounds at appropriate points."""
-    key = jax.random.key(0)
+def test_continuous_space_defers_invariant_checks():
+    """Inconsistent bounds are accepted until downstream JAX operations use them."""
+    Continuous(low=jnp.zeros(1), high=jnp.ones(2))
+    Continuous(low=jnp.zeros(1, dtype=jnp.float16), high=jnp.ones(1))
+    Continuous(low=jnp.asarray(0), high=jnp.asarray(1))
 
-    # Test 1: Shape mismatch - fails when accessing shape property
-    with pytest.raises(ValueError, match="low and high must have the same shape"):
-        space = Continuous(low=jnp.array([0.0]), high=jnp.array([1.0, 2.0]))
-        _ = space.shape  # Access shape property to trigger validation
 
-    # Test 1b: Shape mismatch - also fails when calling sample() (which accesses shape)
-    with pytest.raises(ValueError, match="low and high must have the same shape"):
-        space = Continuous(low=jnp.array([0.0]), high=jnp.array([1.0, 2.0]))
-        space.sample(key)  # sample() accesses self.shape, triggering validation
+def test_continuous_space_validation_does_not_concretize_traced_parameters():
+    @jax.jit
+    def sample_continuous(low, high, key):
+        return Continuous(low=low, high=high).sample(key)
 
-    # Test 2: Dtype mismatch - fails when accessing dtype property
-    # Note: JAX may auto-convert dtypes in some cases, so this might not always fail
-    # We test with explicit dtypes that JAX won't auto-convert
-    try:
-        space = Continuous(
-            low=jnp.array([0.0], dtype=jnp.float32),
-            high=jnp.array([1.0], dtype=jnp.float16),
-        )
-        _ = space.dtype  # Access dtype property to trigger validation
-        # If we get here, JAX auto-converted the dtype, which is acceptable
-    except ValueError as e:
-        assert "low and high must have the same dtype" in str(e)
-
-    # Test 2b: Dtype mismatch - also fails when calling sample() (which accesses dtype)
-    try:
-        space = Continuous(
-            low=jnp.array([0.0], dtype=jnp.float32),
-            high=jnp.array([1.0], dtype=jnp.float16),
-        )
-        space.sample(key)  # sample() accesses self.dtype, triggering validation
-        # If we get here, JAX auto-converted the dtype, which is acceptable
-    except ValueError as e:
-        assert "low and high must have the same dtype" in str(e)
+    sample = sample_continuous(jnp.zeros(2), jnp.ones(2), jax.random.key(0))
+    assert sample.shape == (2,)
 
 
 # ============================================================================
@@ -217,16 +194,42 @@ def test_continuous_space_validation():
 # ============================================================================
 
 
-def test_continuous_contains_wrong_dtype():
-    """Test Continuous.contains with wrong dtype values."""
-    space = Continuous.from_shape(low=0.0, high=1.0, shape=(2,))
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.float32, jnp.int8, jnp.int32])
+def test_continuous_contains_accepts_real_numeric_dtypes(dtype):
+    space = Continuous.from_shape(low=0.0, high=2.0, shape=(2,))
 
-    # Should work with float32
-    assert space.contains(jnp.array([0.5, 0.5], dtype=jnp.float32))
+    assert space.contains(jnp.array([1, 2], dtype=dtype))
 
-    # Should also work with int (gets converted/compared)
-    # Note: int array [0, 1] should be in range [0.0, 1.0]
-    assert space.contains(jnp.array([0, 1], dtype=jnp.int32))
+
+@pytest.mark.parametrize(
+    "candidate", [jnp.array([True, False]), jnp.array([1 + 0j, 2 + 0j])]
+)
+def test_continuous_contains_rejects_non_real_numeric_dtypes(candidate):
+    space = Continuous.from_shape(low=0.0, high=2.0, shape=(2,))
+
+    assert not space.contains(candidate)
+
+
+@pytest.mark.parametrize("candidate", [jnp.array(0.5), jnp.ones((1, 2))])
+def test_continuous_contains_requires_exact_shape(candidate):
+    assert not Continuous.from_shape(0.0, 1.0, (2,)).contains(candidate)
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        Continuous.from_shape(-jnp.inf, jnp.inf, (3,)),
+        Continuous(
+            low=jnp.array([-jnp.inf, 0.0, -jnp.inf, 1.0]),
+            high=jnp.array([jnp.inf, jnp.inf, 2.0, 1.0]),
+        ),
+    ],
+)
+def test_unbounded_continuous_sampling_is_finite_and_contained(space):
+    samples = jax.vmap(space.sample)(jax.random.split(jax.random.key(0), 32))
+
+    assert jnp.all(jnp.isfinite(samples))
+    assert jnp.all(jax.vmap(space.contains)(samples))
 
 
 def test_continuous_space_replace():

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -14,12 +14,6 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     pytest.skip("hypothesis not installed", allow_module_level=True)
 
-try:
-    from hypothesis import given, settings
-    from hypothesis import strategies as st
-except ImportError:  # pragma: no cover - optional dependency
-    pytest.skip("hypothesis not installed", allow_module_level=True)
-
 # ============================================================================
 # Tests: Discrete Space - Basic Functionality
 # ============================================================================
@@ -102,7 +96,7 @@ def test_discrete_space_sampling(
 )
 def test_discrete_space_contains_array(value, expected):
     """Parameterised coverage for array inputs to Discrete.contains."""
-    space = Discrete(n=10)
+    space = Discrete.from_shape(n=10, shape=(3,))
     assert space.contains(value) == expected
 
 
@@ -134,6 +128,21 @@ def test_discrete_space_jit():
 
     assert 0 <= sample < 10
     assert valid
+
+
+def test_discrete_contains_shape_and_dtype_guards_under_jit_and_vmap():
+    space = Discrete.from_shape(4, (2,))
+    contains = jax.jit(space.contains)
+
+    assert bool(contains(jnp.asarray([0, 3], dtype=jnp.int32)))
+    assert not bool(contains(jnp.asarray([0.0, 3.0], dtype=jnp.float32)))
+    assert not bool(contains(jnp.asarray([0], dtype=jnp.int32)))
+
+    candidates = jnp.asarray([[0, 1], [3, 3], [1, 4]], dtype=jnp.int32)
+    assert jnp.array_equal(
+        jax.vmap(space.contains)(candidates),
+        jnp.asarray([True, True, False]),
+    )
 
 
 def test_discrete_space_different_dtypes():
@@ -169,18 +178,13 @@ def test_discrete_tree_operations():
 # ============================================================================
 
 
-def test_discrete_contains_wrong_dtype():
-    """Test Discrete.contains with wrong dtype values."""
+@pytest.mark.parametrize("dtype", [jnp.int8, jnp.int16, jnp.int32, jnp.uint8])
+def test_discrete_contains_uses_integer_dtype_category(dtype):
     space = Discrete(n=10)
 
-    # Should work with int32
-    assert space.contains(jnp.array(5, dtype=jnp.int32))
-
-    # Should also work with different int dtype (gets compared as numbers)
-    assert space.contains(jnp.array(5, dtype=jnp.int16))
-
-    # Float values should work if they're within range
-    assert space.contains(jnp.array(5.0, dtype=jnp.float32))
+    assert space.contains(jnp.array(5, dtype=dtype))
+    assert not space.contains(jnp.array(5.0, dtype=jnp.float32))
+    assert not space.contains(jnp.array(True))
 
 
 def test_discrete_space_replace():
@@ -190,6 +194,19 @@ def test_discrete_space_replace():
     assert new_discrete.n == 20
     assert new_discrete.dtype == jnp.int32
     assert discrete.n == 10  # Original unchanged
+
+
+@pytest.mark.parametrize("candidate", [jnp.array(1), jnp.ones((1, 2), dtype=int)])
+def test_discrete_contains_requires_exact_shape(candidate):
+    assert not Discrete.from_shape(3, (2,)).contains(candidate)
+
+
+def test_discrete_space_validation_does_not_concretize_traced_parameters():
+    @jax.jit
+    def sample_discrete(n, key):
+        return Discrete(n=n).sample(key)
+
+    assert sample_discrete(jnp.array(3), jax.random.key(0)).shape == ()
 
 
 @given(

--- a/tests/spaces/test_pytree_space.py
+++ b/tests/spaces/test_pytree_space.py
@@ -162,7 +162,7 @@ def test_pytree_space_contains_structure_errors(candidate, message):
         }
     )
 
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(ValueError):
         space.contains(candidate)
 
 
@@ -176,10 +176,10 @@ def test_pytree_space_contains_list_structure_mismatch():
     )
 
     # Wrong list length - JAX catches arity mismatch
-    with pytest.raises(ValueError, match="arity mismatch"):
+    with pytest.raises(ValueError):
         space.contains([5])  # Too short
 
-    with pytest.raises(ValueError, match="arity mismatch"):
+    with pytest.raises(ValueError):
         space.contains([5, jnp.array([0.5, 0.5]), 10])  # Too long
 
     # Wrong type (dict instead of list) - JAX catches this

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -147,6 +147,26 @@ def test_container_extras_use_canonical_key_order():
     assert all(jnp.array_equal(a, b) for a, b in zip(xy_leaves, yx_leaves))
 
 
+def test_direct_extras_mappings_use_canonical_key_order():
+    yx = InfoLike(
+        a=jnp.array(0),
+        b=jnp.array(0),
+        _extras={"y": jnp.array(2), "x": jnp.array(1)},
+    )
+    xy = InfoLike(
+        a=jnp.array(0),
+        b=jnp.array(0),
+        _extras={"x": jnp.array(10), "y": jnp.array(20)},
+    )
+
+    assert jax.tree.structure(yx) == jax.tree.structure(xy)
+
+    select = jax.jit(lambda pred: jax.lax.cond(pred, lambda: yx, lambda: xy))
+    selected = select(False)
+    assert selected.x == 10
+    assert selected.y == 20
+
+
 def test_same_container_extras_schema_composes_in_lax_cond():
     base = InfoLike(a=jnp.array(0), b=jnp.array(0))
     xy = base.update(x=jnp.array(1), y=jnp.array(2))

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -136,17 +136,28 @@ def test_container_treedef_and_leaf_order_behavior():
     assert jnp.allclose(rec2.y, c2.y)
 
 
-def test_extras_insertion_order_does_not_affect_treedef():
-    """Extras inserted in different order should produce the same pytree structure."""
-    c1 = SimpleContainer(x=jnp.array(1), y=jnp.array(0)).update(b=jnp.array(2), a=jnp.array(3))
-    c2 = SimpleContainer(x=jnp.array(1), y=jnp.array(0)).update(a=jnp.array(3), b=jnp.array(2))
+def test_container_extras_use_canonical_key_order():
+    base = InfoLike(a=jnp.array(0), b=jnp.array(0))
+    xy = base.update(x=jnp.array(1), y=jnp.array(2))
+    yx = base.update(y=jnp.array(2), x=jnp.array(1))
 
-    children1, treedef1 = jax.tree_util.tree_flatten(c1)
-    children2, treedef2 = jax.tree_util.tree_flatten(c2)
+    xy_leaves, xy_def = jax.tree.flatten(xy)
+    yx_leaves, yx_def = jax.tree.flatten(yx)
+    assert xy_def == yx_def
+    assert all(jnp.array_equal(a, b) for a, b in zip(xy_leaves, yx_leaves))
 
-    assert treedef1 == treedef2
-    for l1, l2 in zip(children1, children2):
-        assert jnp.array_equal(l1, l2)
+
+def test_same_container_extras_schema_composes_in_lax_cond():
+    base = InfoLike(a=jnp.array(0), b=jnp.array(0))
+    xy = base.update(x=jnp.array(1), y=jnp.array(2))
+    yx = base.update(y=jnp.array(20), x=jnp.array(10))
+
+    select = jax.jit(lambda pred: jax.lax.cond(pred, lambda: xy, lambda: yx))
+    selected = select(False)
+    assert selected.x == 10
+    assert selected.y == 20
+
+    assert jax.tree.structure(base.update(x=1)) != jax.tree.structure(base.update(y=1))
 
 
 # ============================================================================

--- a/tests/test_distribution_artifacts.py
+++ b/tests/test_distribution_artifacts.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+pytestmark = pytest.mark.packaging
+
+
+def _artifact_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    configured = os.environ.get("ENVELOPE_DIST_DIR")
+    if configured is not None:
+        output = Path(configured)
+        return output if output.is_absolute() else ROOT / output
+
+    output = tmp_path / "dist"
+    monkeypatch.setenv("UV_PYTHON", "3.12")
+    subprocess.run(
+        ["uv", "build", "--no-sources", "--out-dir", str(output)],
+        cwd=ROOT,
+        check=True,
+    )
+    return output
+
+
+def test_built_artifacts_respect_the_release_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = _artifact_directory(tmp_path, monkeypatch)
+
+    sdists = list(output.glob("*.tar.gz"))
+    wheels = list(output.glob("*.whl"))
+    assert len(sdists) == 1, f"expected one sdist in {output}, found {sdists}"
+    assert len(wheels) == 1, f"expected one wheel in {output}, found {wheels}"
+    sdist = sdists[0]
+    wheel = wheels[0]
+
+    with tarfile.open(sdist, "r:gz") as archive:
+        relative_members = {
+            member.name.split("/", 1)[1]
+            for member in archive.getmembers()
+            if "/" in member.name
+        }
+
+    allowed_directories = {"src", "tests", "docs", ".github"}
+    allowed_files = {
+        ".gitignore",
+        ".readthedocs.yaml",
+        "LICENSE",
+        "README.md",
+        "PKG-INFO",
+        "mkdocs.yml",
+        "pyproject.toml",
+    }
+    unexpected = {
+        name
+        for name in relative_members
+        if name.split("/", 1)[0] not in allowed_directories
+        and name not in allowed_files
+    }
+    assert not unexpected
+    assert not any(
+        ".claude" in name or "benchmarks" in name for name in relative_members
+    )
+
+    with zipfile.ZipFile(wheel) as archive:
+        wheel_members = set(archive.namelist())
+
+    assert "envelope/py.typed" in wheel_members
+    assert not any(name.startswith("examples/") for name in wheel_members)
+    assert sdist.stat().st_size < 2_000_000
+    assert wheel.stat().st_size < 1_000_000

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,47 @@
+from functools import cached_property
+
+import jax.numpy as jnp
+import pytest
+
+from envelope.environment import Environment, InfoContainer
+from envelope.spaces import Continuous
+
+
+class MinimalEnvironment(Environment):
+    @cached_property
+    def observation_space(self) -> Continuous:
+        return Continuous(low=-jnp.inf, high=jnp.inf)
+
+    @cached_property
+    def action_space(self) -> Continuous:
+        return Continuous(low=-1.0, high=1.0)
+
+    def init(self, key):
+        del key
+        state = jnp.asarray(0.0)
+        return state, InfoContainer(
+            obs=state, reward=0.0, terminated=False, truncated=False
+        )
+
+    def step(self, state, action):
+        state = state + action
+        return state, InfoContainer(
+            obs=state, reward=action, terminated=False, truncated=False
+        )
+
+
+def test_space_descriptors_remain_abstract() -> None:
+    class MissingSpaces(Environment):
+        def init(self, key):
+            raise NotImplementedError
+
+        def step(self, state, action):
+            raise NotImplementedError
+
+    assert {"observation_space", "action_space"} <= Environment.__abstractmethods__
+    with pytest.raises(TypeError, match="abstract"):
+        MissingSpaces()
+
+
+def test_default_max_steps_is_none_by_default() -> None:
+    assert MinimalEnvironment().default_max_steps is None

--- a/tests/test_public_typing.py
+++ b/tests/test_public_typing.py
@@ -1,0 +1,18 @@
+"""Runtime-facing expectations for Envelope's inline typing surface."""
+
+from importlib import resources
+
+import pytest
+
+import envelope
+import envelope.typing as envelope_typing
+
+
+@pytest.mark.parametrize("name", ["Array", "Info", "Key", "PyTree", "State"])
+def test_typing_names_are_exported_from_package_root(name):
+    assert name in envelope.__all__
+    assert getattr(envelope, name) is getattr(envelope_typing, name)
+
+
+def test_package_contains_pep561_marker_for_built_wheels():
+    assert resources.files("envelope").joinpath("py.typed").is_file()

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -37,11 +37,11 @@ class _NodeWithDefaults(FrozenPyTreeNode):
     scale: float = static_field(default=1.0)
 
 
-class _NodeWithDefaultList(FrozenPyTreeNode):
-    """Helper node for default_factory independence checks."""
+class _NodeWithDefaultTuple(FrozenPyTreeNode):
+    """Helper node for immutable static-field defaults."""
 
     x: jax.Array
-    items: list = static_field(default_factory=list)
+    items: tuple[int, ...] = static_field(default_factory=tuple)
 
 
 class _BaseNode(FrozenPyTreeNode):
@@ -76,7 +76,7 @@ class _ComplexNode(FrozenPyTreeNode):
     int_static: int = static_field()
     another_array: jax.Array
     str_static: str = static_field()
-    list_static: list = static_field()
+    tuple_static: tuple[int, ...] = static_field()
 
 
 # ============================================================================
@@ -245,6 +245,28 @@ class TestPyTreeNodeJAXIntegration:
         assert jnp.allclose(reconstructed.y, node.y)
         assert reconstructed.static_val == node.static_val
 
+    def test_tree_unflatten_bypasses_constructor_validation_for_jax_sentinels(self):
+        """Opaque JAX bookkeeping values must not enter ``__post_init__``."""
+
+        class ValidatedNode(FrozenPyTreeNode):
+            value: jax.Array
+            label: str = static_field()
+
+            def __post_init__(self):
+                if not isinstance(self.value, jax.Array):
+                    raise TypeError("value must be a JAX array")
+
+        node = ValidatedNode(value=jnp.asarray(1.0), label="valid")
+        _, treedef = jax.tree_util.tree_flatten(node)
+        sentinel = object()
+
+        with pytest.raises(TypeError, match="JAX array"):
+            ValidatedNode(value=sentinel, label="invalid")
+
+        reconstructed = jax.tree_util.tree_unflatten(treedef, [sentinel])
+        assert reconstructed.value is sentinel
+        assert reconstructed.label == "valid"
+
     def test_jax_tree_map(self):
         """Test that jax.tree.map works correctly with PyTreeNode."""
         node = SimpleNode(
@@ -327,7 +349,7 @@ class TestPyTreeNodeJAXIntegration:
                     int_static=42,
                     another_array=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
                     str_static="metadata",
-                    list_static=[1, 2, 3],
+                    tuple_static=(1, 2, 3),
                 ),
                 id="complex-node",
             ),
@@ -449,22 +471,66 @@ class TestPyTreeNodeDefaults:
 
         class NodeWithStaticDefault(FrozenPyTreeNode):
             x: jax.Array
-            config: dict = static_field(default_factory=dict)
+            config: tuple[str, ...] = static_field(default_factory=tuple)
             threshold: float = static_field(default=0.5)
 
         # Create with defaults
         node1 = NodeWithStaticDefault(x=jnp.array([1.0]))
         assert jnp.allclose(node1.x, jnp.array([1.0]))
-        assert node1.config == {}
+        assert node1.config == ()
         assert node1.threshold == 0.5
 
         # Create with explicit values
         node2 = NodeWithStaticDefault(
-            x=jnp.array([2.0]), config={"key": "value"}, threshold=0.9
+            x=jnp.array([2.0]), config=("value",), threshold=0.9
         )
         assert jnp.allclose(node2.x, jnp.array([2.0]))
-        assert node2.config == {"key": "value"}
+        assert node2.config == ("value",)
         assert node2.threshold == 0.9
+
+    @pytest.mark.parametrize(
+        "value_factory",
+        [list, dict, set, lambda: jnp.array([1, 2])],
+        ids=["list", "dict", "set", "jax-array"],
+    )
+    def test_static_field_rejects_mutable_or_unhashable_metadata(self, value_factory):
+        class Node(FrozenPyTreeNode):
+            x: jax.Array
+            metadata: object = static_field()
+
+        with pytest.raises(TypeError, match="static"):
+            Node(x=jnp.array(1.0), metadata=value_factory())
+
+    def test_static_field_unsafe_opt_in_allows_opaque_metadata(self):
+        class Node(FrozenPyTreeNode):
+            x: jax.Array
+            metadata: object = static_field(unsafe=True)
+
+        metadata = {"mutable": []}
+        node = Node(x=jnp.array(1.0), metadata=metadata)
+        assert node.metadata is metadata
+
+    def test_subclass_post_init_must_call_super_for_static_validation(self):
+        class UnvalidatedNode(FrozenPyTreeNode):
+            x: jax.Array
+            metadata: object = static_field(default=None)
+
+            def __post_init__(self):
+                object.__setattr__(self, "metadata", {"mutable": []})
+
+        node = UnvalidatedNode(x=jnp.array(1.0))
+        assert node.metadata == {"mutable": []}
+
+        class ValidatedNode(FrozenPyTreeNode):
+            x: jax.Array
+            metadata: object = static_field(default=None)
+
+            def __post_init__(self):
+                object.__setattr__(self, "metadata", {"mutable": []})
+                super().__post_init__()
+
+        with pytest.raises(TypeError, match="static"):
+            ValidatedNode(x=jnp.array(1.0))
 
     def test_mixed_required_and_default_fields(self):
         """Test nodes with mix of required and default fields."""
@@ -497,18 +563,10 @@ class TestPyTreeNodeDefaults:
         assert node2.d == "custom"
         assert jnp.allclose(node2.e, jnp.array([2.0, 3.0]))
 
-    def test_default_factory_independence(self):
-        """Test that default_factory creates independent instances."""
-
-        node1 = _NodeWithDefaultList(x=jnp.array([1.0]))
-        node2 = _NodeWithDefaultList(x=jnp.array([2.0]))
-
-        # Modify node1's list (if it weren't frozen)
-        # Since the node is frozen, we can't modify in place, but we can check
-        # that the default_factory created different instances
-        assert node1.items is not node2.items
-        assert node1.items == []
-        assert node2.items == []
+    def test_immutable_static_default_factory(self):
+        node1 = _NodeWithDefaultTuple(x=jnp.array([1.0]))
+        node2 = _NodeWithDefaultTuple(x=jnp.array([2.0]))
+        assert node1.items == node2.items == ()
 
 
 # ============================================================================

--- a/tests/wrappers/helpers.py
+++ b/tests/wrappers/helpers.py
@@ -7,6 +7,7 @@ deterministic, and easy to compose across wrapper unit tests.
 from __future__ import annotations
 
 from functools import cached_property
+from math import prod
 
 import jax
 import jax.numpy as jnp
@@ -276,6 +277,42 @@ class ScalarToyEnv(Environment):
         return ns, info
 
 
+class NonzeroInitInfoEnv(Environment):
+    """Reset-equivalent env whose initial info has nonzero leaves of varied dtypes."""
+
+    @cached_property
+    def observation_space(self) -> Continuous:
+        return Continuous(low=-jnp.inf, high=jnp.inf)
+
+    @cached_property
+    def action_space(self) -> Continuous:
+        return Continuous(low=-1.0, high=1.0)
+
+    def init(self, key: Key) -> tuple[jax.Array, InfoContainer]:
+        state = jnp.asarray(7.0, dtype=jnp.float32)
+        info = InfoContainer(
+            obs=state,
+            reward=jnp.asarray(3.0, dtype=jnp.float16),
+            terminated=jnp.asarray(True),
+            truncated=jnp.asarray(True),
+        ).update(counter=jnp.asarray([2, 4], dtype=jnp.int16))
+        return state, info
+
+    def reset(self, state: State, key: Key) -> tuple[jax.Array, InfoContainer]:
+        return self.init(key)
+
+    def step(
+        self, state: jax.Array, action: jax.Array
+    ) -> tuple[jax.Array, InfoContainer]:
+        next_state = state + action
+        return next_state, InfoContainer(
+            obs=next_state,
+            reward=jnp.asarray(action, dtype=jnp.float16),
+            terminated=jnp.asarray(False),
+            truncated=jnp.asarray(False),
+        ).update(counter=jnp.asarray([2, 4], dtype=jnp.int16))
+
+
 class VectorToyEnv(Environment):
     """Action/obs are vectors of length D."""
 
@@ -434,7 +471,7 @@ class PyTreeObsEnv(Environment):
 
     def init(self, key: Key):
         obs = {
-            k: jnp.arange(jnp.prod(jnp.asarray(v)), dtype=jnp.float32).reshape(v)
+            k: jnp.arange(prod(v), dtype=jnp.float32).reshape(v)
             for k, v in self.shapes.items()
         }
         s = obs
@@ -446,7 +483,10 @@ class PyTreeObsEnv(Environment):
     def step(self, state: State, action: jax.Array):
         ns = state
         return ns, InfoContainer(
-            obs=state, reward=float(action), terminated=False, truncated=False
+            obs=state,
+            reward=jnp.asarray(action, dtype=jnp.float32),
+            terminated=False,
+            truncated=False,
         )
 
 
@@ -563,7 +603,8 @@ class RandomImageEnv(Environment):
     @cached_property
     def observation_space(self) -> Continuous:
         return Continuous(
-            low=-jnp.inf, high=jnp.inf, shape=self.shape, dtype=jnp.float32
+            low=jnp.full(self.shape, -jnp.inf, dtype=self.dtype),
+            high=jnp.full(self.shape, jnp.inf, dtype=self.dtype),
         )
 
     @cached_property

--- a/tests/wrappers/test_autoreset_wrapper.py
+++ b/tests/wrappers/test_autoreset_wrapper.py
@@ -64,18 +64,12 @@ class TestAutoResetCoreFunctionality:
         state, _ = w.init(key)
         # Step until termination
         state, _ = w.step(state, jnp.array(0.1))
-        state, _ = w.step(state, jnp.array(0.2))  # This should trigger termination
+        state, info = w.step(state, jnp.array(0.2))
 
-        # Next step should auto-reset
-        next_state, next_info = w.step(state, jnp.array(0.3))
-
-        # State should be reset (steps back to 0 or 1 after reset+step)
-        # After auto-reset, we take a step, so steps should be 1
-        assert next_state.unwrapped.steps == 1
-        # Env state should be reset (0.0) plus the action (0.3)
-        assert jnp.allclose(next_state.unwrapped.env_state, jnp.array(0.3))
-        # Info should be from reset+step, not the terminated step
-        assert bool(jnp.asarray(next_info.terminated)) is False
+        assert state.unwrapped.steps == 0
+        assert jnp.allclose(state.unwrapped.env_state, jnp.array(0.0))
+        assert bool(jnp.asarray(info.terminated)) is True
+        assert jnp.allclose(info.final.obs, jnp.array(0.3))
 
     def test_step_when_truncated_auto_resets(self):
         """Verify that when info.truncated=True, the wrapper automatically calls reset."""
@@ -86,16 +80,12 @@ class TestAutoResetCoreFunctionality:
         state, _ = w.init(key)
         # Step until truncation
         state, _ = w.step(state, jnp.array(0.1))
-        state, _ = w.step(state, jnp.array(0.2))  # This should trigger truncation
+        state, info = w.step(state, jnp.array(0.2))
 
-        # Next step should auto-reset
-        next_state, next_info = w.step(state, jnp.array(0.3))
-
-        # State should be reset
-        assert next_state.unwrapped.steps == 1
-        assert jnp.allclose(next_state.unwrapped.env_state, jnp.array(0.3))
-        # Info should be from reset+step
-        assert bool(jnp.asarray(next_info.truncated)) is False
+        assert state.unwrapped.steps == 0
+        assert jnp.allclose(state.unwrapped.env_state, jnp.array(0.0))
+        assert bool(jnp.asarray(info.truncated)) is True
+        assert jnp.allclose(info.final.obs, jnp.array(0.3))
 
     def test_step_when_both_terminated_and_truncated(self):
         """Verify behavior when both terminated and truncated are True."""
@@ -111,10 +101,10 @@ class TestAutoResetCoreFunctionality:
         # After reset, state should be fresh (steps=0, env_state=0.0)
         assert next_state.unwrapped.steps == 0
         assert jnp.allclose(next_state.unwrapped.env_state, jnp.array(0.0))
-        # After auto-reset, returned info is from reset (new episode)
-        assert bool(jnp.asarray(next_info.terminated)) is False
-        assert bool(jnp.asarray(next_info.truncated)) is False
-        assert jnp.allclose(next_info.reward, 0.0)
+        # Observation/state are reset, but transition fields remain terminal.
+        assert bool(jnp.asarray(next_info.terminated)) is True
+        assert bool(jnp.asarray(next_info.truncated)) is True
+        assert jnp.allclose(next_info.reward, 0.5)
 
     def test_reset_key_usage(self):
         """Verify that the stored reset_key is used for auto-reset."""
@@ -158,7 +148,7 @@ class TestAutoResetStateInfoPropagation:
         assert jnp.allclose(state.unwrapped.env_state, jnp.array(0.0))
 
     def test_info_after_auto_reset_preserves_terminal_info(self):
-        """After auto-reset, returned info is from reset; terminal step is in info.final."""
+        """Auto-reset keeps terminal transition fields and stores the full snapshot."""
         env = StepCounterEnv(terminate_after=1)
         w = AutoResetWrapper(env)
         key = jax.random.key(0)
@@ -167,10 +157,10 @@ class TestAutoResetStateInfoPropagation:
         # Step to trigger termination - this will auto-reset immediately since done=True
         state, info = w.step(state, jnp.array(0.1))
 
-        # Returned info is from reset (new episode)
-        assert bool(jnp.asarray(info.terminated)) is False
+        # Observation is from reset; reward/done describe the terminal transition.
+        assert bool(jnp.asarray(info.terminated)) is True
         assert bool(jnp.asarray(info.truncated)) is False
-        assert jnp.allclose(info.reward, 0.0)
+        assert jnp.allclose(info.reward, 0.1)
         # Terminal step snapshot is in info.final
         assert bool(jnp.asarray(info.final.terminated)) is True
         assert jnp.allclose(info.final.reward, 0.1)
@@ -204,15 +194,14 @@ class TestAutoResetStateInfoPropagation:
         key = jax.random.key(0)
 
         state, _ = w.init(key)
-        # Every step will be done, so should auto-reset each time; returned info is from reset
+        # Every step is terminal and immediately resets the state/observation.
         for i in range(3):
             action = jnp.array(0.1 * (i + 1))
             state, info = w.step(state, action)
 
-            # Returned info is from reset
-            assert bool(jnp.asarray(info.terminated)) is False
+            assert bool(jnp.asarray(info.terminated)) is True
             assert bool(jnp.asarray(info.truncated)) is False
-            assert jnp.allclose(info.reward, 0.0)
+            assert jnp.allclose(info.reward, action)
             # State should reflect the reset (steps=0, env_state=0.0)
             assert state.unwrapped.steps == 0
             assert jnp.allclose(state.unwrapped.env_state, jnp.array(0.0))
@@ -239,11 +228,11 @@ class TestAutoResetEdgeCases:
         # First step should terminate
         next_state, next_info = w.step(state, jnp.array(0.1))
 
-        # Should auto-reset; returned info is from reset, terminal step in next_info.final
+        # State/observation reset while transition fields and final remain terminal.
         assert next_state.unwrapped.steps == 0
         assert jnp.allclose(next_state.unwrapped.env_state, jnp.array(0.0))
-        assert bool(jnp.asarray(next_info.terminated)) is False
-        assert jnp.allclose(next_info.reward, 0.0)
+        assert bool(jnp.asarray(next_info.terminated)) is True
+        assert jnp.allclose(next_info.reward, 0.1)
         assert bool(jnp.asarray(next_info.final.terminated)) is True
         assert jnp.allclose(next_info.final.reward, 0.1)
 
@@ -275,11 +264,10 @@ class TestAutoResetEdgeCases:
         key = jax.random.key(0)
 
         state, _ = w.init(key)
-        # Take several steps. After a terminal step we return reset info (terminated=False).
-        # So returned info.terminated is always False; terminal snapshot is in info.final when applicable.
+        # Reset returns to step zero, so every step is terminal in this environment.
         for i in range(5):
             state, info = w.step(state, jnp.array(0.1))
-            assert bool(jnp.asarray(info.terminated)) is False
+            assert bool(jnp.asarray(info.terminated)) is True
 
     def test_reset_key_regeneration(self):
         """Verify that each reset generates a new reset_key."""
@@ -395,8 +383,8 @@ class TestAutoResetComposability:
         assert jnp.allclose(info2.obs[0], 0.0, atol=0.01)
         assert jnp.allclose(info2.obs[1], 0.2, atol=0.01)
         assert jnp.allclose(info2.obs[2], 0.2, atol=0.01)
-        # First env was reset so returned info has terminated=False
-        assert bool(jnp.asarray(info2.terminated[0])) is False
+        # First env reset, while its transition flag remains terminal.
+        assert bool(jnp.asarray(info2.terminated[0])) is True
         assert bool(jnp.asarray(info2.terminated[1])) is False
         assert bool(jnp.asarray(info2.terminated[2])) is False
 
@@ -405,9 +393,7 @@ class TestAutoResetComposability:
         # After auto-reset, second env should be reset
         # First env: 0.0 + 0.1 = 0.1 (reset state + action), Second: reset to 0.0, Third: 0.2 + 0.1 = 0.3
         assert jnp.allclose(info3.obs[1], 0.0, atol=0.01)
-        assert (
-            bool(jnp.asarray(info3.terminated[1])) is False
-        )  # Reset, so returned terminated=False
+        assert bool(jnp.asarray(info3.terminated[1])) is True
 
     def test_with_vmap_envs_wrapper(self):
         """Test autoreset with VmapEnvsWrapper (batched environment instances)."""
@@ -432,9 +418,7 @@ class TestAutoResetComposability:
         # First env should be reset (obs ~0.0 from reset state), others continue (obs ~0.2)
         assert jnp.allclose(info2.obs[0], 0.0, atol=0.01)
         assert jnp.allclose(info2.obs[1], 0.2, atol=0.01)
-        assert (
-            bool(jnp.asarray(info2.terminated[0])) is False
-        )  # Reset, so returned terminated=False
+        assert bool(jnp.asarray(info2.terminated[0])) is True
 
     def test_nested_wrappers(self):
         """Test autoreset with multiple wrapper layers."""
@@ -511,8 +495,8 @@ class TestAutoResetJITCompatibility:
 
         rewards = episode_fn(key)
         assert rewards.shape == (10,)
-        # With terminate_after=3: on terminal steps (2, 5, 8) returned reward is from reset (0)
-        expected_rewards = jnp.array([0.1, 0.1, 0.0, 0.1, 0.1, 0.0, 0.1, 0.1, 0.0, 0.1])
+        # Terminal rewards remain observable even though the state immediately resets.
+        expected_rewards = jnp.full((10,), 0.1)
         assert jnp.allclose(rewards, expected_rewards)
 
 
@@ -596,7 +580,7 @@ def test_final_obs_preserved_after_auto_reset():
 
 
 def test_terminated_flag_preserved_after_auto_reset():
-    """After auto-reset, returned info is from reset; terminal step is in info2.final."""
+    """After auto-reset, terminal fields remain top-level and in info.final."""
     env = StepCounterEnv(terminate_after=2)
     w = AutoResetWrapper(env)
     key = jax.random.key(0)
@@ -612,16 +596,15 @@ def test_terminated_flag_preserved_after_auto_reset():
     # Step 2: terminates and auto-resets
     state, info2 = w.step(state, jnp.array(0.2))
 
-    # Returned info is from reset
-    assert bool(jnp.asarray(info2.terminated)) is False
-    assert jnp.allclose(info2.reward, jnp.array(0.0))
+    assert bool(jnp.asarray(info2.terminated)) is True
+    assert jnp.allclose(info2.reward, jnp.array(0.2))
     # Terminal step snapshot is in info2.final
     assert bool(jnp.asarray(info2.final.terminated)) is True
     assert jnp.allclose(info2.final.reward, jnp.array(0.2))
 
 
 def test_truncated_flag_preserved_after_auto_reset():
-    """After auto-reset, returned info is from reset; truncated step is in info2.final."""
+    """After auto-reset, truncation remains top-level and in info.final."""
     env = StepCounterEnv(truncate_after=2)
     w = AutoResetWrapper(env)
     key = jax.random.key(0)
@@ -635,9 +618,28 @@ def test_truncated_flag_preserved_after_auto_reset():
     # Step 2: truncates and auto-resets
     state, info2 = w.step(state, jnp.array(0.2))
 
-    # Returned info is from reset
-    assert bool(jnp.asarray(info2.truncated)) is False
-    assert jnp.allclose(info2.reward, jnp.array(0.0))
+    assert bool(jnp.asarray(info2.truncated)) is True
+    assert jnp.allclose(info2.reward, jnp.array(0.2))
     # Truncated step snapshot is in info2.final
     assert bool(jnp.asarray(info2.final.truncated)) is True
     assert jnp.allclose(info2.final.reward, jnp.array(0.2))
+
+
+def test_final_valid_and_last_final_persist_into_next_episode():
+    env = StepCounterEnv(terminate_after=2)
+    w = AutoResetWrapper(env)
+    state, initial_info = w.init(jax.random.key(0))
+
+    assert bool(jnp.asarray(initial_info.final_valid)) is False
+
+    state, first_info = w.step(state, jnp.asarray(0.1))
+    assert bool(jnp.asarray(first_info.final_valid)) is False
+
+    state, terminal_info = w.step(state, jnp.asarray(0.2))
+    assert bool(jnp.asarray(terminal_info.final_valid)) is True
+    assert jnp.allclose(terminal_info.final.obs, 0.3)
+
+    state, next_info = w.step(state, jnp.asarray(0.4))
+    assert bool(jnp.asarray(next_info.final_valid)) is True
+    assert jnp.allclose(next_info.final.obs, terminal_info.final.obs)
+    assert jnp.allclose(state.last_final.obs, terminal_info.final.obs)

--- a/tests/wrappers/test_environment_wrapper.py
+++ b/tests/wrappers/test_environment_wrapper.py
@@ -243,6 +243,17 @@ class TestWrapperAttributeDelegation:
         with pytest.raises(AttributeError):
             _ = environment_wrapper.nonexistent_attribute
 
+    def test_wrapper_descriptor_attribute_error_is_not_silently_delegated(self):
+        class BrokenPropertyWrapper(Wrapper):
+            @property
+            def custom_property(self):
+                raise AttributeError("wrapper property failed")
+
+        environment_wrapper = BrokenPropertyWrapper(WrapperEnvWithMethods())
+
+        with pytest.raises(AttributeError, match="wrapper property failed"):
+            _ = environment_wrapper.custom_property
+
     def test_getattr_setstate_raises(self):
         """Verify __setstate__ raises AttributeError."""
         env = WrapperSimpleEnv()

--- a/tests/wrappers/test_episode_statistics_wrapper.py
+++ b/tests/wrappers/test_episode_statistics_wrapper.py
@@ -57,24 +57,22 @@ def test_info_contains_stats_field():
     assert isinstance(info.stats, EpisodeStatistics)
 
 
-def test_reset_preserves_stats():
+def test_reset_clears_episode_stats():
     env = StepCounterEnv()
     w = EpisodeStatisticsWrapper(env)
     key = jax.random.key(0)
     state, _ = w.init(key)
     for _ in range(3):
         state, _ = w.step(state, jnp.asarray(0.2))
-    reward_before = state.stats.reward
-    length_before = state.stats.length
     state, info = w.reset(state, key)
-    assert jnp.allclose(state.stats.reward, reward_before)
-    assert jnp.allclose(state.stats.length, length_before)
-    assert jnp.allclose(info.stats.reward, reward_before)
-    assert jnp.allclose(info.stats.length, length_before)
+    assert jnp.allclose(state.stats.reward, 0.0)
+    assert jnp.allclose(state.stats.length, 0)
+    assert jnp.allclose(info.stats.reward, 0.0)
+    assert jnp.allclose(info.stats.length, 0)
     assert w.observation_space.contains(info.obs)
 
 
-def test_stats_persist_and_continue_after_reset():
+def test_stats_restart_after_reset():
     env = StepCounterEnv()
     w = EpisodeStatisticsWrapper(env)
     key = jax.random.key(0)
@@ -84,9 +82,8 @@ def test_stats_persist_and_continue_after_reset():
     state, _ = w.reset(state, key)
     for _ in range(2):
         state, _ = w.step(state, jnp.asarray(0.1))
-    # Total length = 3 + 2 = 5, reward = 0.1*5 = 0.5
-    assert jnp.allclose(state.stats.length, 5)
-    assert jnp.allclose(state.stats.reward, 0.5)
+    assert jnp.allclose(state.stats.length, 2)
+    assert jnp.allclose(state.stats.reward, 0.2)
 
 
 def test_negative_rewards_accumulate_correctly():
@@ -158,17 +155,42 @@ def test_jit_init_step_loop():
     assert jnp.allclose(jnp.asarray(stats.reward), 0.4)
 
 
-def test_composability_with_vmap_wrapper():
+def test_must_be_applied_before_vmap_wrapper():
     batch_size = 3
     env = StepCounterEnv()
-    w = EpisodeStatisticsWrapper(VmapWrapper(env, batch_size=batch_size))
+    w = VmapWrapper(EpisodeStatisticsWrapper(env), batch_size=batch_size)
     key = jax.random.key(0)
-    state, _ = w.init(key)
-    action = jnp.array([0.1, 0.2, 0.3])
-    state, info = w.step(state, action)
-    # Reward is batched; length may be scalar or batched depending on implementation
+    state, info = w.init(key)
     assert jnp.asarray(state.stats.reward).shape == (batch_size,)
-    assert jnp.allclose(jnp.asarray(state.stats.reward), action)
+    assert jnp.asarray(state.stats.length).shape == (batch_size,)
+    assert jnp.asarray(info.stats.reward).shape == (batch_size,)
+
+    actions = jnp.asarray([[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]])
+    state, _ = jax.lax.scan(
+        lambda carry, action: (w.step(carry, action)[0], None), state, actions
+    )
+
+    assert jnp.asarray(state.stats.reward).shape == (batch_size,)
+    assert jnp.asarray(state.stats.length).shape == (batch_size,)
+    assert jnp.allclose(jnp.asarray(state.stats.reward), actions.sum(axis=0))
+    assert jnp.all(state.stats.length == 2)
+
+
+def test_tracks_vector_rewards_outside_vmap():
+    env = VmapWrapper(StepCounterEnv(), batch_size=3)
+    wrapper = EpisodeStatisticsWrapper(env)
+    state, _ = wrapper.init(jax.random.key(0))
+    actions = jnp.asarray([[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]])
+
+    state, infos = jax.lax.scan(
+        lambda carry, action: wrapper.step(carry, action), state, actions
+    )
+
+    assert state.stats.reward.shape == (3,)
+    assert state.stats.length.shape == (3,)
+    assert jnp.allclose(state.stats.reward, actions.sum(axis=0))
+    assert jnp.all(state.stats.length == 2)
+    assert infos.stats.reward.shape == (2, 3)
 
 
 def test_composability_with_truncation_wrapper():

--- a/tests/wrappers/test_flatten_action_wrapper.py
+++ b/tests/wrappers/test_flatten_action_wrapper.py
@@ -115,12 +115,7 @@ def test_action_space_flattened_discrete():
     w = FlattenActionWrapper(env)
     space = w.action_space
     assert isinstance(space, Discrete)
-    assert space.shape == (
-        2,
-    )  # 2 + 3 = 5 elements? No - Discrete(n=2) has shape (), Discrete(n=3) has ().
-    # Actually flatten_space on PyTreeSpace of Discrete: shape is PyTree of shapes. Discrete has shape ().
-    # So shapes are [(), ()] and dims [1, 1] for n=2 and n=3? No - prod(()) = 1. So total dim 2.
-    # And Discrete concatenation: n = concat([2, 3]) = array [2, 3], shape (2,). So action_space is Discrete(n=[2,3]).
+    # Each scalar Discrete leaf contributes one event dimension.
     assert space.shape == (2,)
 
 
@@ -178,13 +173,12 @@ def test_mixed_space_types_raises_value_error():
 
 
 def test_jit_step():
-    """Step produces correct output. Full JIT of step is not supported: unflatten_x uses jnp.split(..., indices) with space-derived indices, which triggers ConcretizationTypeError under jit."""
     env = PyTreeActionEnv()
     w = FlattenActionWrapper(env)
     key = jax.random.key(0)
     state, _ = w.init(key)
     action = w.action_space.sample(key)
-    next_state, info = w.step(state, action)
+    next_state, info = jax.jit(w.step)(state, action)
     assert next_state.shape == (5,)
     assert info.obs.shape == (5,)
 
@@ -212,4 +206,18 @@ def test_composability_with_vmap_wrapper():
     action = w.action_space.sample(key)
     assert action.shape == (batch_size, 5)
     state, info = w.step(state, action)
+    assert info.obs.shape == (batch_size, 5)
+
+
+def test_flatten_action_outside_vmap_preserves_batch_prefix_under_jit():
+    batch_size = 2
+    w = FlattenActionWrapper(VmapWrapper(PyTreeActionEnv(), batch_size=batch_size))
+    key = jax.random.key(0)
+    state, _ = w.init(key)
+    action = w.action_space.sample(key)
+
+    next_state, info = jax.jit(w.step)(state, action)
+
+    assert action.shape == (batch_size, 5)
+    assert next_state.shape == (batch_size, 5)
     assert info.obs.shape == (batch_size, 5)

--- a/tests/wrappers/test_flatten_observation_wrapper.py
+++ b/tests/wrappers/test_flatten_observation_wrapper.py
@@ -176,3 +176,20 @@ def test_composability_with_vmap_wrapper():
     assert info.obs.shape == (batch_size, 5)
     assert isinstance(w.observation_space, BatchedSpace)
     assert w.observation_space.space.shape == (5,)
+
+
+def test_flatten_observation_outside_vmap_preserves_batch_prefix():
+    batch_size = 4
+    w = FlattenObservationWrapper(
+        VmapWrapper(
+            PyTreeObsEnv(shapes={"a": (2,), "b": (3,)}),
+            batch_size=batch_size,
+        )
+    )
+
+    state, info = w.init(jax.random.key(0))
+    _, step_info = jax.jit(w.step)(state, jnp.zeros((batch_size,)))
+
+    assert w.observation_space.shape == (batch_size, 5)
+    assert info.obs.shape == (batch_size, 5)
+    assert step_info.obs.shape == (batch_size, 5)

--- a/tests/wrappers/test_hardening_contracts.py
+++ b/tests/wrappers/test_hardening_contracts.py
@@ -1,0 +1,181 @@
+"""Focused cross-wrapper contracts for the Envelope 0.5 lifecycle semantics."""
+
+import inspect
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from envelope.wrappers.autoreset_wrapper import AutoResetWrapper
+from envelope.wrappers.continuous_observation_wrapper import (
+    ContinuousObservationWrapper,
+)
+from envelope.wrappers.episode_statistics_wrapper import EpisodeStatisticsWrapper
+from envelope.wrappers.flatten_observation_wrapper import FlattenObservationWrapper
+from envelope.wrappers.pooled_init_vmap_wrapper import PooledInitVmapWrapper
+from envelope.wrappers.state_injection_wrapper import StateInjectionWrapper
+from envelope.wrappers.truncation_wrapper import TruncationWrapper
+from envelope.wrappers.vmap_wrapper import VmapWrapper
+from tests.wrappers.helpers import NonzeroInitInfoEnv, PyTreeObsEnv, StepCounterEnv
+
+
+@pytest.mark.parametrize(
+    "make_env",
+    [
+        lambda: ContinuousObservationWrapper(StepCounterEnv()),
+        lambda: FlattenObservationWrapper(PyTreeObsEnv(shapes={"a": (2,), "b": (3,)})),
+        lambda: EpisodeStatisticsWrapper(StepCounterEnv()),
+        lambda: AutoResetWrapper(StepCounterEnv()),
+        lambda: PooledInitVmapWrapper(StepCounterEnv(), batch_size=2, pool_size=2),
+    ],
+    ids=[
+        "continuous-observation",
+        "flatten-observation",
+        "episode-statistics",
+        "autoreset",
+        "pooled-init-vmap",
+    ],
+)
+def test_reset_accepts_canonical_state_key_keywords(make_env: Callable[[], object]):
+    env = make_env()
+    key = jax.random.key(0)
+    state, _ = env.init(key)
+
+    parameter_names = list(inspect.signature(type(env).reset).parameters)
+    assert parameter_names[:3] == ["self", "state", "key"]
+
+    reset_state, reset_info = env.reset(state, jax.random.key(1))
+    keyword_state, keyword_info = env.reset(state=state, key=jax.random.key(1))
+
+    assert reset_state is not None
+    assert reset_info is not None
+    assert jax.tree.structure(keyword_state) == jax.tree.structure(reset_state)
+    assert jax.tree.structure(keyword_info) == jax.tree.structure(reset_info)
+
+
+def test_documented_episode_stack_runs_through_boundary_under_jit_scan():
+    env = VmapWrapper(
+        AutoResetWrapper(
+            EpisodeStatisticsWrapper(
+                TruncationWrapper(StepCounterEnv(terminate_after=2), max_steps=5)
+            )
+        ),
+        batch_size=2,
+    )
+    state, _ = env.init(jax.random.key(0))
+    actions = jnp.asarray([[0.1, 0.1], [0.2, 0.2]], dtype=jnp.float32)
+
+    @jax.jit
+    def rollout(initial_state, xs):
+        return jax.lax.scan(
+            lambda carry, action: env.step(carry, action), initial_state, xs
+        )
+
+    _, infos = rollout(state, actions)
+
+    assert jnp.all(infos.final_valid[0] == jnp.asarray([False, False]))
+    assert jnp.all(infos.final_valid[1] == jnp.asarray([True, True]))
+    assert jnp.all(infos.terminated[1])
+    assert jnp.allclose(infos.reward[1], jnp.asarray([0.2, 0.2]))
+    assert jnp.allclose(infos.stats.reward[1], jnp.asarray([0.0, 0.0]))
+    assert jnp.allclose(infos.final.stats.reward[1], jnp.asarray([0.3, 0.3]))
+    assert jnp.all(infos.final.stats.length[1] == 2)
+
+
+def test_autoreset_rejects_vectorization_on_the_inside():
+    with pytest.raises(
+        ValueError, match="AutoResetWrapper cannot contain VmapWrapper"
+    ):
+        AutoResetWrapper(VmapWrapper(StepCounterEnv(), batch_size=2))
+
+
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "jit"])
+@pytest.mark.parametrize("wrapper_kind", ["autoreset", "pooled"])
+def test_initial_final_is_a_type_preserving_zero_placeholder(
+    wrapper_kind: str, compiled: bool
+):
+    base = NonzeroInitInfoEnv()
+    key = jax.random.key(0)
+    if wrapper_kind == "autoreset":
+        env = AutoResetWrapper(base)
+        _, reference_info = base.init(key)
+    else:
+        batch_size = 2
+        env = PooledInitVmapWrapper(base, batch_size=batch_size, pool_size=batch_size)
+        keys = jax.random.split(key, batch_size)
+        _, reference_info = jax.vmap(base.init)(keys)
+
+    init = jax.jit(env.init) if compiled else env.init
+    state, info = init(key)
+
+    assert jnp.all(jnp.asarray(info.final_valid) == 0)
+    for placeholder in (state.last_final, info.final):
+        assert jax.tree.structure(placeholder) == jax.tree.structure(reference_info)
+        for actual, reference in zip(
+            jax.tree.leaves(placeholder), jax.tree.leaves(reference_info)
+        ):
+            actual = jnp.asarray(actual)
+            reference = jnp.asarray(reference)
+            assert actual.shape == reference.shape
+            assert actual.dtype == reference.dtype
+            assert jnp.all(actual == jnp.zeros_like(reference))
+
+
+@pytest.mark.parametrize(
+    "make_env",
+    [
+        lambda: EpisodeStatisticsWrapper(AutoResetWrapper(StepCounterEnv())),
+        lambda: EpisodeStatisticsWrapper(
+            PooledInitVmapWrapper(StepCounterEnv(), batch_size=2, pool_size=2)
+        ),
+        lambda: TruncationWrapper(AutoResetWrapper(StepCounterEnv()), max_steps=5),
+        lambda: TruncationWrapper(
+            PooledInitVmapWrapper(StepCounterEnv(), batch_size=2, pool_size=2),
+            max_steps=5,
+        ),
+        lambda: StateInjectionWrapper(AutoResetWrapper(StepCounterEnv())),
+        lambda: StateInjectionWrapper(
+            PooledInitVmapWrapper(StepCounterEnv(), batch_size=2, pool_size=2)
+        ),
+    ],
+    ids=[
+        "episode-stats-outside-autoreset",
+        "episode-stats-outside-pooled",
+        "truncation-outside-autoreset",
+        "truncation-outside-pooled",
+        "state-injection-outside-autoreset",
+        "state-injection-outside-pooled",
+    ],
+)
+def test_unconstrained_wrapper_orders_construct(
+    make_env: Callable[[], object],
+):
+    assert make_env() is not None
+
+
+@pytest.mark.parametrize(
+    "make_env",
+    [
+        lambda: AutoResetWrapper(
+            EpisodeStatisticsWrapper(
+                TruncationWrapper(StateInjectionWrapper(StepCounterEnv()), max_steps=5)
+            )
+        ),
+        lambda: PooledInitVmapWrapper(
+            EpisodeStatisticsWrapper(TruncationWrapper(StepCounterEnv(), max_steps=5)),
+            batch_size=2,
+            pool_size=2,
+        ),
+    ],
+    ids=["autoreset", "pooled"],
+)
+def test_canonical_wrapper_orders_remain_jittable(make_env: Callable[[], object]):
+    env = make_env()
+    key = jax.random.key(0)
+    state, _ = jax.jit(env.init)(key)
+    action = env.action_space.sample(key)
+    next_state, info = jax.jit(env.step)(state, action)
+
+    assert next_state is not None
+    assert info is not None

--- a/tests/wrappers/test_hardening_contracts.py
+++ b/tests/wrappers/test_hardening_contracts.py
@@ -84,9 +84,7 @@ def test_documented_episode_stack_runs_through_boundary_under_jit_scan():
 
 
 def test_autoreset_rejects_vectorization_on_the_inside():
-    with pytest.raises(
-        ValueError, match="AutoResetWrapper cannot contain VmapWrapper"
-    ):
+    with pytest.raises(ValueError, match="AutoResetWrapper cannot contain VmapWrapper"):
         AutoResetWrapper(VmapWrapper(StepCounterEnv(), batch_size=2))
 
 

--- a/tests/wrappers/test_normalization.py
+++ b/tests/wrappers/test_normalization.py
@@ -16,7 +16,8 @@ def _init_rmv_from_example(x_like, dtype=jnp.float32, count=0) -> RunningMeanVar
 
     mean0 = jax.tree.map(zeros_no_batch, x_like)
     var0 = jax.tree.map(ones_no_batch, x_like)
-    return RunningMeanVar(mean=mean0, var=var0, count=count)
+    count0 = jax.tree.map(lambda _: jnp.asarray(count), x_like)
+    return RunningMeanVar(mean=mean0, var=var0, count=count0)
 
 
 @pytest.mark.parametrize(
@@ -108,7 +109,16 @@ def test_update_rmv_pytree_leaves():
     assert jnp.allclose(rmv1.var["a"], exp_var_a, atol=1e-6, rtol=1e-6)
     assert jnp.allclose(rmv1.mean["b"], exp_mean_b, atol=1e-6, rtol=1e-6)
     assert jnp.allclose(rmv1.var["b"], exp_var_b, atol=1e-6, rtol=1e-6)
-    assert rmv1.count == 32
+    assert rmv1.count.keys() == x.keys()
+    assert rmv1.count["a"] == 32
+    assert rmv1.count["b"] == 32
+    assert jax.tree.all(
+        jax.tree.map(
+            lambda std, var: jnp.allclose(std, jnp.sqrt(var)),
+            rmv1.std,
+            rmv1.var,
+        )
+    )
 
 
 def test_update_rmv_jit_compatibility():

--- a/tests/wrappers/test_observation_normalization_wrapper.py
+++ b/tests/wrappers/test_observation_normalization_wrapper.py
@@ -1,20 +1,119 @@
 import pickle
+from functools import cached_property
 
 import jax
 import jax.numpy as jnp
 import pytest
 
+from envelope.environment import Environment, InfoContainer
+from envelope.spaces import Continuous, PyTreeSpace
+from envelope.wrappers.autoreset_wrapper import AutoResetWrapper
 from envelope.wrappers.normalization import RunningMeanVar, update_rmv
 from envelope.wrappers.observation_normalization_wrapper import (
     ObservationNormalizationWrapper,
 )
+from envelope.wrappers.pooled_init_vmap_wrapper import PooledInitVmapWrapper
+from envelope.wrappers.vmap_envs_wrapper import VmapEnvsWrapper
 from envelope.wrappers.vmap_wrapper import VmapWrapper
 from tests.wrappers.helpers import (
     ConstantObsEnv,
     IntObsEnv,
+    PyTreeObsEnv,
     RandomImageEnv,
+    StepCounterEnv,
     VectorObsEnv,
 )
+
+
+class RowStructuredObsEnv(Environment):
+    """Two rows with distinct means, used to test broadcast-aware statistics."""
+
+    @cached_property
+    def observation_space(self):
+        return Continuous.from_shape(-jnp.inf, jnp.inf, (2, 3, 1))
+
+    @cached_property
+    def action_space(self):
+        return Continuous(low=-1.0, high=1.0)
+
+    def init(self, key):
+        obs = jnp.asarray([[[0.0], [0.0], [0.0]], [[10.0], [10.0], [10.0]]])
+        return obs, InfoContainer(
+            obs=obs, reward=0.0, terminated=False, truncated=False
+        )
+
+    def reset(self, state, key):
+        return self.init(key)
+
+    def step(self, state, action):
+        return state, InfoContainer(
+            obs=state, reward=0.0, terminated=False, truncated=False
+        )
+
+
+class HeterogeneousStatsEnv(Environment):
+    """Leaves whose broadcast statistics consume different sample counts."""
+
+    @cached_property
+    def observation_space(self):
+        return PyTreeSpace(
+            (
+                Continuous.from_shape(-jnp.inf, jnp.inf, (2,)),
+                Continuous.from_shape(-jnp.inf, jnp.inf, (2, 3)),
+            )
+        )
+
+    @cached_property
+    def action_space(self):
+        return Continuous(low=-1.0, high=1.0)
+
+    def init(self, key):
+        obs = (
+            jnp.asarray([1.0, 3.0]),
+            jnp.asarray([[0.0, 2.0, 4.0], [10.0, 12.0, 14.0]]),
+        )
+        return obs, InfoContainer(
+            obs=obs, reward=0.0, terminated=False, truncated=False
+        )
+
+    def reset(self, state, key):
+        return self.init(key)
+
+    def step(self, state, action):
+        return state, InfoContainer(
+            obs=state, reward=0.0, terminated=False, truncated=False
+        )
+
+
+class ActionTerminationEnv(Environment):
+    """Scalar env whose batch elements can finish on different actions."""
+
+    @cached_property
+    def observation_space(self):
+        return Continuous(low=-jnp.inf, high=jnp.inf)
+
+    @cached_property
+    def action_space(self):
+        return Continuous(low=-1.0, high=1.0)
+
+    def init(self, key):
+        state = jnp.asarray(0.0, dtype=jnp.float32)
+        return state, InfoContainer(
+            obs=state,
+            reward=jnp.asarray(0.0, dtype=jnp.float32),
+            terminated=jnp.asarray(False),
+            truncated=jnp.asarray(False),
+        )
+
+    def step(self, state, action):
+        next_state = state + action
+        return next_state, InfoContainer(
+            obs=next_state,
+            reward=action,
+            terminated=action >= 0.75,
+            truncated=jnp.asarray(False),
+        )
+
 
 # -----------------------------------------------------------------------------
 # Core: stats_spec inference and dtype validation
@@ -26,8 +125,7 @@ def test_stats_spec_infers_from_unbatched_space():
     # Wrap with vmap first to add batch dimension, then normalize
     vm = VmapWrapper(base, batch_size=7)
     w = ObservationNormalizationWrapper(vm)
-    # stats_spec should match unbatched obs leaves
-    sd = w.stats_spec  # jax.ShapeDtypeStruct for leaf
+    sd = w.stats_spec
     assert hasattr(sd, "shape") and hasattr(sd, "dtype")
     assert sd.shape == base.observation_space.shape
     assert sd.dtype == base.observation_space.dtype
@@ -37,6 +135,22 @@ def test_non_floating_observation_raises():
     env = IntObsEnv()
     with pytest.raises(ValueError):
         _ = ObservationNormalizationWrapper(env)
+
+
+@pytest.mark.parametrize("spec_source", ["inferred", "provided"])
+def test_pytree_stats_spec_is_available_and_jittable(spec_source):
+    env = PyTreeObsEnv(shapes={"a": (2,), "b": (3,)})
+    expected_spec = {
+        "a": jax.ShapeDtypeStruct((2,), jnp.float32),
+        "b": jax.ShapeDtypeStruct((3,), jnp.float32),
+    }
+    stats_spec = None if spec_source == "inferred" else expected_spec
+
+    wrapper = ObservationNormalizationWrapper(env, stats_spec=stats_spec)
+
+    assert jax.tree.structure(wrapper.stats_spec) == jax.tree.structure(expected_spec)
+    _state, info = jax.jit(wrapper.init)(jax.random.key(0))
+    assert jax.tree.structure(info.obs) == jax.tree.structure(expected_spec)
 
 
 # -----------------------------------------------------------------------------
@@ -108,6 +222,125 @@ def test_jit_compatibility_smoke():
     cnt, shape = run_once(key, action)
     # Only check shapes; count semantics differ under various compositions
     assert shape == (4, 3)
+
+
+def _shared_autoreset_normalizer() -> ObservationNormalizationWrapper:
+    termination_steps = jnp.asarray([2, 3])
+    envs = jax.vmap(
+        lambda terminate_after: StepCounterEnv(terminate_after=terminate_after)
+    )(termination_steps)
+    return ObservationNormalizationWrapper(
+        VmapEnvsWrapper(AutoResetWrapper(envs), batch_size=2)
+    )
+
+
+def _normalized_scalar(raw, state):
+    return (raw - state.rmv_state.mean) / (state.rmv_state.std + 1e-8)
+
+
+def test_shared_normalization_handles_partial_terminal_observations():
+    wrapper = _shared_autoreset_normalizer()
+    action = jnp.asarray([0.25, 0.75], dtype=jnp.float32)
+
+    state, initial = wrapper.init(jax.random.key(0))
+
+    assert state.rmv_state.count == 2
+    assert jnp.all(~initial.final_valid)
+    assert jnp.allclose(initial.final.obs, jnp.zeros(2))
+    assert jnp.allclose(initial.final.unnormalized_obs, jnp.zeros(2))
+
+    state, _ = wrapper.step(state, action)
+    state, first_completion = jax.jit(wrapper.step)(state, action)
+
+    assert jnp.array_equal(first_completion.terminated, jnp.asarray([True, False]))
+    assert jnp.array_equal(first_completion.final_valid, jnp.asarray([True, False]))
+    assert jnp.allclose(
+        first_completion.final.obs[0],
+        _normalized_scalar(first_completion.final.unnormalized_obs[0], state),
+    )
+    assert first_completion.final.obs[1] == 0
+
+    state, second_completion = wrapper.step(state, action)
+
+    assert jnp.array_equal(second_completion.terminated, jnp.asarray([False, True]))
+    assert jnp.all(second_completion.final_valid)
+    assert jnp.allclose(
+        second_completion.final.obs,
+        _normalized_scalar(second_completion.final.unnormalized_obs, state),
+    )
+    assert state.rmv_state.count == 8
+
+
+def test_shared_normalization_preserves_final_across_manual_reset_and_scan():
+    wrapper = _shared_autoreset_normalizer()
+    actions = jnp.full((3, 2), 0.5, dtype=jnp.float32)
+    state, _ = wrapper.init(jax.random.key(0))
+
+    @jax.jit
+    def run_steps(scan_state, scan_actions):
+        return jax.lax.scan(wrapper.step, scan_state, scan_actions)
+
+    state, infos = run_steps(state, actions)
+    raw_final = infos.final.unnormalized_obs[-1]
+    count_before_reset = state.rmv_state.count
+
+    state, reset_info = jax.jit(wrapper.reset)(state, jax.random.key(1))
+
+    assert jnp.array_equal(reset_info.final.unnormalized_obs, raw_final)
+    assert jnp.allclose(
+        reset_info.final.obs,
+        _normalized_scalar(reset_info.final.unnormalized_obs, state),
+    )
+    assert state.rmv_state.count == count_before_reset + 2
+
+
+def test_terminal_placeholder_uses_normalized_dtype_and_fixed_schema():
+    wrapper = ObservationNormalizationWrapper(
+        VmapWrapper(AutoResetWrapper(StepCounterEnv(terminate_after=1)), batch_size=2),
+        stats_spec=jax.ShapeDtypeStruct((), jnp.float16),
+    )
+
+    state, initial = jax.jit(wrapper.init)(jax.random.key(0))
+    state, completed = jax.jit(wrapper.step)(
+        state, jnp.asarray([0.25, 0.75], dtype=jnp.float32)
+    )
+
+    assert initial.final.obs.dtype == jnp.float16
+    assert jnp.all(initial.final.obs == 0)
+    assert initial.final.unnormalized_obs.dtype == jnp.float32
+    assert jax.tree.structure(initial) == jax.tree.structure(completed)
+    assert completed.final.obs.dtype == jnp.float16
+    assert completed.final.unnormalized_obs.dtype == jnp.float32
+    assert state.rmv_state.count == 4
+
+
+def test_shared_normalization_can_wrap_pooled_initialization():
+    wrapper = ObservationNormalizationWrapper(
+        PooledInitVmapWrapper(ActionTerminationEnv(), batch_size=2, pool_size=2)
+    )
+    state, initial = wrapper.init(jax.random.key(0))
+
+    assert jnp.all(initial.final.obs == 0)
+    assert state.rmv_state.count == 2
+
+    state, first = jax.jit(wrapper.step)(
+        state, jnp.asarray([1.0, 0.25], dtype=jnp.float32)
+    )
+
+    assert jnp.array_equal(first.terminated, jnp.asarray([True, False]))
+    assert jnp.array_equal(first.final_valid, jnp.asarray([True, False]))
+    assert first.final.unnormalized_obs[0] == 1.0
+    assert first.final.obs[1] == 0
+
+    state, second = wrapper.step(state, jnp.asarray([0.1, 1.0], dtype=jnp.float32))
+
+    assert jnp.array_equal(second.terminated, jnp.asarray([False, True]))
+    assert second.final.unnormalized_obs[1] == 1.25
+    assert jnp.allclose(
+        second.final.obs,
+        _normalized_scalar(second.final.unnormalized_obs, state),
+    )
+    assert state.rmv_state.count == 6
 
 
 def test_pickle_running_mean_var_in_state():
@@ -213,6 +446,8 @@ def test_image_channelwise_stats_spec_dtype_cast():
     key = jax.random.key(0)
     state, info = w.init(key)
     assert info.obs.dtype == jnp.bfloat16
+    assert w.observation_space.shape == (B, H, W, C)
+    assert w.observation_space.dtype == jnp.bfloat16
     state, info = w.step(state, jnp.zeros((B,)))
     assert info.obs.dtype == jnp.bfloat16
 
@@ -226,5 +461,49 @@ def test_scalar_stats_spec_broadcast_to_vector_and_cast():
     key = jax.random.key(0)
     state, info = w.init(key)
     assert jnp.asarray(info.obs).dtype == jnp.float16
+    assert w.observation_space.dtype == jnp.float16
     state, info = w.step(state, jnp.zeros((B, D), dtype=jnp.float32))
     assert jnp.asarray(info.obs).dtype == jnp.float16
+
+
+def test_broadcast_stats_spec_reduces_the_broadcast_axes():
+    spec = jax.ShapeDtypeStruct((2, 1, 1), jnp.float32)
+    w = ObservationNormalizationWrapper(RowStructuredObsEnv(), stats_spec=spec)
+
+    state, info = w.init(jax.random.key(0))
+
+    assert jnp.allclose(state.rmv_state.mean[:, 0, 0], jnp.asarray([0.0, 10.0]))
+    assert jnp.allclose(info.obs, jnp.zeros((2, 3, 1)), atol=1e-6)
+
+
+def test_broadcast_statistics_track_per_leaf_effective_counts_under_jit():
+    stats_spec = (
+        jax.ShapeDtypeStruct((2,), jnp.float32),
+        jax.ShapeDtypeStruct((1, 3), jnp.float32),
+    )
+    wrapper = ObservationNormalizationWrapper(
+        HeterogeneousStatsEnv(), stats_spec=stats_spec
+    )
+
+    state, _ = wrapper.init(jax.random.key(0))
+
+    assert jax.tree.structure(state.rmv_state.count) == jax.tree.structure(stats_spec)
+    assert state.rmv_state.count[0] == 1
+    assert state.rmv_state.count[1] == 2
+
+    state, _ = jax.jit(wrapper.step)(state, jnp.asarray(0.0))
+    assert state.rmv_state.count[0] == 2
+    assert state.rmv_state.count[1] == 4
+
+
+def test_constant_float16_observations_remain_finite():
+    spec = jax.ShapeDtypeStruct((3,), jnp.float16)
+    w = ObservationNormalizationWrapper(
+        ConstantObsEnv(value=7.0, shape=(3,), dtype=jnp.float16),
+        stats_spec=spec,
+    )
+
+    _, info = w.init(jax.random.key(0))
+
+    assert info.obs.dtype == jnp.float16
+    assert jnp.all(jnp.isfinite(info.obs))

--- a/tests/wrappers/test_pooled_init_vmap_wrapper.py
+++ b/tests/wrappers/test_pooled_init_vmap_wrapper.py
@@ -172,9 +172,7 @@ def test_pooled_incompatibilities_are_rejected(env, error_pattern):
     ids=["vmap", "vmap-envs"],
 )
 def test_vectorization_is_rejected_inside_pool(env):
-    with pytest.raises(
-        ValueError, match="PooledInitVmapWrapper cannot contain Vmap"
-    ):
+    with pytest.raises(ValueError, match="PooledInitVmapWrapper cannot contain Vmap"):
         PooledInitVmapWrapper(env, batch_size=2, pool_size=2)
 
 

--- a/tests/wrappers/test_pooled_init_vmap_wrapper.py
+++ b/tests/wrappers/test_pooled_init_vmap_wrapper.py
@@ -1,12 +1,21 @@
+from dataclasses import fields
+
 import jax
 import jax.numpy as jnp
 import pytest
 
 from envelope.spaces import BatchedSpace
+from envelope.wrappers.autoreset_wrapper import AutoResetWrapper
 from envelope.wrappers.episode_statistics_wrapper import EpisodeStatisticsWrapper
+from envelope.wrappers.observation_normalization_wrapper import (
+    ObservationNormalizationWrapper,
+)
 from envelope.wrappers.pooled_init_vmap_wrapper import PooledInitVmapWrapper
+from envelope.wrappers.state_injection_wrapper import StateInjectionWrapper
 from envelope.wrappers.truncation_wrapper import TruncationWrapper
-from tests.wrappers.helpers import ScalarToyEnv, StepCounterEnv
+from envelope.wrappers.vmap_envs_wrapper import VmapEnvsWrapper
+from envelope.wrappers.vmap_wrapper import VmapWrapper
+from tests.wrappers.helpers import ParamEnv, ScalarToyEnv, StepCounterEnv
 
 
 def test_init_creates_batched_state():
@@ -18,15 +27,15 @@ def test_init_creates_batched_state():
     assert info.obs.shape == (batch_size,)
 
 
-def test_init_last_final_is_nan_placeholder():
+def test_init_last_final_is_type_preserving_placeholder():
     batch_size = 2
     env = ScalarToyEnv()
     w = PooledInitVmapWrapper(env, batch_size=batch_size, pool_size=2)
     key = jax.random.key(0)
     state, info = w.init(key)
-    # last_final should be info-shaped with NaN
-    assert jnp.all(jnp.isnan(state.last_final.obs))
-    assert jnp.all(jnp.isnan(jnp.asarray(state.last_final.reward).reshape(-1)))
+    assert state.last_final.obs.dtype == info.obs.dtype
+    assert state.last_final.terminated.dtype == info.terminated.dtype
+    assert jnp.all(info.final_valid == jnp.asarray([False, False]))
 
 
 def test_init_info_has_final_field():
@@ -35,7 +44,8 @@ def test_init_info_has_final_field():
     key = jax.random.key(0)
     state, info = w.init(key)
     assert hasattr(info, "final")
-    assert jnp.all(jnp.isnan(info.final.obs))
+    assert jnp.all(info.final_valid == jnp.asarray([False, False]))
+    assert info.final.obs.dtype == info.obs.dtype
 
 
 def test_step_non_done_envs_continue_normally():
@@ -100,6 +110,82 @@ def test_step_info_final_field():
     # For done env: final is terminal info
     assert hasattr(info, "final")
     assert jnp.allclose(info.final.obs, jnp.array([0.5]))
+
+
+def test_terminal_transition_semantics_match_scalar_autoreset():
+    scalar = AutoResetWrapper(StepCounterEnv(terminate_after=1))
+    pooled = PooledInitVmapWrapper(
+        StepCounterEnv(terminate_after=1), batch_size=1, pool_size=1
+    )
+    key = jax.random.key(0)
+    scalar_state, _ = scalar.init(key)
+    pooled_state, _ = pooled.init(key)
+
+    _, scalar_info = scalar.step(scalar_state, jnp.asarray(0.5))
+    _, pooled_info = pooled.step(pooled_state, jnp.asarray([0.5]))
+
+    assert bool(jnp.asarray(scalar_info.terminated)) is True
+    assert bool(jnp.asarray(pooled_info.terminated[0])) is True
+    assert jnp.allclose(scalar_info.reward, pooled_info.reward[0])
+    assert jnp.allclose(scalar_info.obs, pooled_info.obs[0])
+    assert jnp.allclose(scalar_info.final.obs, pooled_info.final.obs[0])
+    assert bool(jnp.asarray(scalar_info.final_valid)) is True
+    assert bool(jnp.asarray(pooled_info.final_valid[0])) is True
+
+
+@pytest.mark.parametrize(
+    "env,error_pattern",
+    [
+        (
+            AutoResetWrapper(ScalarToyEnv()),
+            "AutoResetWrapper cannot be inside PooledInitVmapWrapper",
+        ),
+        (
+            StateInjectionWrapper(ScalarToyEnv()),
+            "StateInjectionWrapper cannot be inside PooledInitVmapWrapper",
+        ),
+        (
+            ObservationNormalizationWrapper(ScalarToyEnv()),
+            "ObservationNormalizationWrapper cannot be inside PooledInitVmapWrapper",
+        ),
+        (
+            PooledInitVmapWrapper(ScalarToyEnv(), batch_size=2, pool_size=2),
+            "PooledInitVmapWrapper cannot contain PooledInitVmapWrapper",
+        ),
+    ],
+    ids=["autoreset", "state-injection", "normalization", "pooled-vmap"],
+)
+def test_pooled_incompatibilities_are_rejected(env, error_pattern):
+    with pytest.raises(ValueError, match=error_pattern):
+        PooledInitVmapWrapper(env, batch_size=2, pool_size=2)
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        VmapWrapper(ScalarToyEnv(), batch_size=2),
+        VmapEnvsWrapper(
+            ParamEnv(offset=jnp.asarray([0.0, 1.0])),
+            batch_size=2,
+        ),
+    ],
+    ids=["vmap", "vmap-envs"],
+)
+def test_vectorization_is_rejected_inside_pool(env):
+    with pytest.raises(
+        ValueError, match="PooledInitVmapWrapper cannot contain Vmap"
+    ):
+        PooledInitVmapWrapper(env, batch_size=2, pool_size=2)
+
+
+def test_pool_sizes_are_static_pytree_metadata():
+    config_fields = {
+        dataclass_field.name: dataclass_field
+        for dataclass_field in fields(PooledInitVmapWrapper)
+    }
+
+    assert config_fields["batch_size"].metadata["pytree_node"] is False
+    assert config_fields["pool_size"].metadata["pytree_node"] is False
 
 
 def test_reset_vmaps_inner_reset():
@@ -198,7 +284,7 @@ def test_no_envs_done():
     state, _ = w.init(key)
     state, info = w.step(state, jnp.array([0.1, 0.2, 0.3]))
     assert jnp.allclose(info.obs, jnp.array([0.1, 0.2, 0.3]))
-    assert jnp.all(jnp.isnan(state.last_final.obs))
+    assert jnp.all(info.final_valid == jnp.asarray([False, False, False]))
 
 
 def test_batch_size_one_pool_size_one():
@@ -263,15 +349,21 @@ def test_jax_lax_scan_multi_step_loop():
     assert obs_stack.shape == (5, 2)
 
 
-def test_composability_with_episode_statistics_wrapper():
+def test_episode_statistics_outside_pooled_tracks_vector_rewards():
     env = StepCounterEnv(terminate_after=2)
-    w = EpisodeStatisticsWrapper(PooledInitVmapWrapper(env, batch_size=2, pool_size=2))
-    key = jax.random.key(0)
-    state, _ = w.init(key)
-    for _ in range(4):
-        state, _ = w.step(state, jnp.array([0.1, 0.1]))
-    # Stats accumulate across pool resets; reward is batched
-    assert jnp.asarray(state.stats.reward).shape == (2,)
+    wrapper = EpisodeStatisticsWrapper(
+        PooledInitVmapWrapper(env, batch_size=2, pool_size=2)
+    )
+    state, _ = wrapper.init(jax.random.key(0))
+    actions = jnp.asarray([[0.1, 0.2], [0.3, 0.4]])
+
+    state, infos = jax.lax.scan(
+        lambda carry, action: wrapper.step(carry, action), state, actions
+    )
+
+    assert state.stats.reward.shape == (2,)
+    assert state.stats.length.shape == (2,)
+    assert infos.stats.reward.shape == (2, 2)
 
 
 def test_composability_with_truncation_wrapper():

--- a/tests/wrappers/test_stack_constraints.py
+++ b/tests/wrappers/test_stack_constraints.py
@@ -83,9 +83,7 @@ def test_constraint_helpers_are_exposed_only_from_wrappers() -> None:
     "make_stack",
     [
         lambda: OuterTarget(RejectOuterTargets(ScalarToyEnv())),
-        lambda: OuterTarget(
-            IntermediateWrapper(RejectOuterTargets(ScalarToyEnv()))
-        ),
+        lambda: OuterTarget(IntermediateWrapper(RejectOuterTargets(ScalarToyEnv()))),
         lambda: OtherOuterTarget(RejectOuterTargets(ScalarToyEnv())),
     ],
     ids=["direct", "indirect", "multiple-match-types"],
@@ -101,9 +99,7 @@ def test_not_inside_searches_the_complete_outer_chain(make_stack) -> None:
     "make_stack",
     [
         lambda: RejectInnerTargets(InnerTarget(ScalarToyEnv())),
-        lambda: RejectInnerTargets(
-            IntermediateWrapper(InnerTarget(ScalarToyEnv()))
-        ),
+        lambda: RejectInnerTargets(IntermediateWrapper(InnerTarget(ScalarToyEnv()))),
         lambda: RejectInnerTargets(OtherInnerTarget(ScalarToyEnv())),
     ],
     ids=["direct", "indirect", "multiple-match-types"],

--- a/tests/wrappers/test_stack_constraints.py
+++ b/tests/wrappers/test_stack_constraints.py
@@ -1,0 +1,156 @@
+from typing import ClassVar
+
+import pytest
+
+import envelope
+from envelope.environment import StackConstraint, not_containing, not_inside
+from envelope.wrappers import (
+    PooledInitializationWrapper,
+    VectorizingWrapper,
+)
+from envelope.wrappers.pooled_init_vmap_wrapper import PooledInitVmapWrapper
+from envelope.wrappers.vmap_wrapper import VmapWrapper
+from envelope.wrappers.wrapper import Wrapper
+from tests.wrappers.helpers import ScalarToyEnv
+
+
+class OuterTarget(Wrapper):
+    pass
+
+
+class OuterTargetSubclass(OuterTarget):
+    pass
+
+
+class OtherOuterTarget(Wrapper):
+    pass
+
+
+class InnerTarget(Wrapper):
+    pass
+
+
+class OtherInnerTarget(Wrapper):
+    pass
+
+
+class IntermediateWrapper(Wrapper):
+    pass
+
+
+class RejectOuterTargets(Wrapper):
+    stack_constraints: ClassVar[tuple[StackConstraint, ...]] = (
+        not_inside(OuterTarget, OtherOuterTarget),
+    )
+
+
+class RejectInnerTargets(Wrapper):
+    stack_constraints: ClassVar[tuple[StackConstraint, ...]] = (
+        not_containing(InnerTarget, OtherInnerTarget),
+    )
+
+
+class CustomVectorizer(Wrapper, VectorizingWrapper):
+    pass
+
+
+class RejectVectorizers(Wrapper):
+    stack_constraints: ClassVar[tuple[StackConstraint, ...]] = (
+        not_containing(VectorizingWrapper),
+    )
+
+
+class PoolUnsafeEnvironment(ScalarToyEnv):
+    stack_constraints: ClassVar[tuple[StackConstraint, ...]] = (
+        not_inside(PooledInitializationWrapper),
+    )
+
+
+def test_constraint_helpers_are_exposed_only_from_wrappers() -> None:
+    from envelope.wrappers import StackConstraint as ExportedStackConstraint
+    from envelope.wrappers import not_containing as exported_not_containing
+    from envelope.wrappers import not_inside as exported_not_inside
+
+    assert ExportedStackConstraint is StackConstraint
+    assert exported_not_inside is not_inside
+    assert exported_not_containing is not_containing
+    assert not hasattr(envelope, "StackConstraint")
+    assert not hasattr(envelope, "not_inside")
+    assert not hasattr(envelope, "not_containing")
+
+
+@pytest.mark.parametrize(
+    "make_stack",
+    [
+        lambda: OuterTarget(RejectOuterTargets(ScalarToyEnv())),
+        lambda: OuterTarget(
+            IntermediateWrapper(RejectOuterTargets(ScalarToyEnv()))
+        ),
+        lambda: OtherOuterTarget(RejectOuterTargets(ScalarToyEnv())),
+    ],
+    ids=["direct", "indirect", "multiple-match-types"],
+)
+def test_not_inside_searches_the_complete_outer_chain(make_stack) -> None:
+    with pytest.raises(
+        ValueError, match="RejectOuterTargets cannot be inside .*OuterTarget"
+    ):
+        make_stack()
+
+
+@pytest.mark.parametrize(
+    "make_stack",
+    [
+        lambda: RejectInnerTargets(InnerTarget(ScalarToyEnv())),
+        lambda: RejectInnerTargets(
+            IntermediateWrapper(InnerTarget(ScalarToyEnv()))
+        ),
+        lambda: RejectInnerTargets(OtherInnerTarget(ScalarToyEnv())),
+    ],
+    ids=["direct", "indirect", "multiple-match-types"],
+)
+def test_not_containing_searches_the_complete_inner_chain(make_stack) -> None:
+    with pytest.raises(
+        ValueError, match="RejectInnerTargets cannot contain .*InnerTarget"
+    ):
+        make_stack()
+
+
+def test_constraints_use_isinstance_for_subclasses() -> None:
+    with pytest.raises(
+        ValueError,
+        match="RejectOuterTargets cannot be inside OuterTargetSubclass",
+    ):
+        OuterTargetSubclass(RejectOuterTargets(ScalarToyEnv()))
+
+
+def test_unrelated_exact_types_do_not_conflict() -> None:
+    stack = IntermediateWrapper(RejectOuterTargets(ScalarToyEnv()))
+    assert isinstance(stack, IntermediateWrapper)
+
+
+def test_marker_mixins_match_custom_wrapper_families() -> None:
+    with pytest.raises(
+        ValueError, match="RejectVectorizers cannot contain CustomVectorizer"
+    ):
+        RejectVectorizers(CustomVectorizer(ScalarToyEnv()))
+
+
+def test_custom_base_environment_can_declare_constraints() -> None:
+    with pytest.raises(
+        ValueError,
+        match="PoolUnsafeEnvironment cannot be inside PooledInitVmapWrapper",
+    ):
+        PooledInitVmapWrapper(
+            PoolUnsafeEnvironment(),
+            batch_size=2,
+            pool_size=2,
+        )
+
+
+def test_builtin_vectorizer_markers_are_structural() -> None:
+    vmap = VmapWrapper(ScalarToyEnv(), batch_size=2)
+    pooled = PooledInitVmapWrapper(ScalarToyEnv(), batch_size=2, pool_size=2)
+
+    assert isinstance(vmap, VectorizingWrapper)
+    assert isinstance(pooled, VectorizingWrapper)
+    assert isinstance(pooled, PooledInitializationWrapper)

--- a/tests/wrappers/test_state_injection_wrapper.py
+++ b/tests/wrappers/test_state_injection_wrapper.py
@@ -5,8 +5,18 @@ import jax.numpy as jnp
 import pytest
 
 from envelope.wrappers.autoreset_wrapper import AutoResetWrapper
+from envelope.wrappers.episode_statistics_wrapper import EpisodeStatisticsWrapper
 from envelope.wrappers.state_injection_wrapper import StateInjectionWrapper
 from tests.wrappers.helpers import StepCounterEnv, StepState
+
+
+def _reset_info_with_obs(state, obs):
+    if hasattr(state, "reset_info"):
+        return state.reset_info.update(obs=obs)
+    if hasattr(state, "inner_state"):
+        return _reset_info_with_obs(state.inner_state, obs)
+    raise ValueError("Could not find injected reset info in state")
+
 
 # ============================================================================
 # Tests: Core Functionality
@@ -29,8 +39,11 @@ class TestStateInjectionCoreFunctionality:
         assert jnp.allclose(state.inner_state.env_state, jnp.array(0.0))
         assert state.inner_state.steps == 0
         assert jnp.allclose(info.obs, jnp.array(0.0))
-        # reset_state is None until set_reset_state is called
-        assert state.reset_state is None
+        assert jax.tree.structure(state.reset_state) == jax.tree.structure(
+            state.inner_state
+        )
+        assert jnp.allclose(state.reset_info.obs, info.obs)
+        assert bool(jnp.asarray(state.active)) is False
 
     def test_set_reset_state_updates_state(self):
         """Verify that set_reset_state() updates the injected state."""
@@ -44,11 +57,16 @@ class TestStateInjectionCoreFunctionality:
         # Set a custom reset state
         custom_state = StepState(env_state=jnp.array(42.0), steps=0)
         custom_obs = jnp.array(42.0)
-        state = w.set_reset_state(state, custom_state, custom_obs)
+        state = w.set_reset_state(
+            state,
+            custom_state,
+            reset_info=_reset_info_with_obs(state, custom_obs),
+        )
 
         # Verify the state was updated
         assert jnp.allclose(state.reset_state.env_state, jnp.array(42.0))
-        assert jnp.allclose(state.reset_obs, custom_obs)
+        assert jnp.allclose(state.reset_info.obs, custom_obs)
+        assert bool(jnp.asarray(state.active)) is True
         # inner_state should also be updated to match
         assert jnp.allclose(state.inner_state.env_state, jnp.array(42.0))
 
@@ -62,7 +80,11 @@ class TestStateInjectionCoreFunctionality:
         state, _ = w.init(key)
         custom_state = StepState(env_state=jnp.array(42.0), steps=0)
         custom_obs = jnp.array(42.0)
-        state = w.set_reset_state(state, custom_state, custom_obs)
+        state = w.set_reset_state(
+            state,
+            custom_state,
+            reset_info=_reset_info_with_obs(state, custom_obs),
+        )
 
         # Reset again, passing the current state (simulates auto-reset)
         key2 = jax.random.key(1)
@@ -83,19 +105,19 @@ class TestStateInjectionCoreFunctionality:
         state = w.set_reset_state(
             state,
             StepState(env_state=jnp.array(1.0), steps=0),
-            jnp.array(1.0),
+            reset_info=_reset_info_with_obs(state, jnp.array(1.0)),
         )
 
         # Set new reset state
         state = w.set_reset_state(
             state,
             StepState(env_state=jnp.array(99.0), steps=0),
-            jnp.array(99.0),
+            reset_info=_reset_info_with_obs(state, jnp.array(99.0)),
         )
 
         # Should have new injected state
         assert jnp.allclose(state.reset_state.env_state, jnp.array(99.0))
-        assert jnp.allclose(state.reset_obs, jnp.array(99.0))
+        assert jnp.allclose(state.reset_info.obs, jnp.array(99.0))
 
     def test_step_updates_inner_state_but_preserves_reset_state(self):
         """Verify that step updates inner_state but keeps reset_state unchanged."""
@@ -107,7 +129,11 @@ class TestStateInjectionCoreFunctionality:
         state, _ = w.init(key)
         custom_state = StepState(env_state=jnp.array(0.0), steps=0)
         custom_obs = jnp.array(0.0)
-        state = w.set_reset_state(state, custom_state, custom_obs)
+        state = w.set_reset_state(
+            state,
+            custom_state,
+            reset_info=_reset_info_with_obs(state, custom_obs),
+        )
 
         # Take a step
         state, info = w.step(state, jnp.array(0.5))
@@ -138,45 +164,42 @@ class TestStateInjectionCoreFunctionality:
         assert jnp.allclose(state2.inner_state.env_state, jnp.array(0.0))
         assert state2.inner_state.steps == 0
         assert jnp.allclose(info2.obs, jnp.array(0.0))
-        # reset_state stays None
-        assert state2.reset_state is None
+        assert bool(jnp.asarray(state2.active)) is False
 
     def test_set_reset_state_raises_on_invalid_state(self):
         """Verify that set_reset_state raises when InjectedState not found."""
         env = StepCounterEnv()
         w = StateInjectionWrapper(env)
+        _, info = w.init(jax.random.key(0))
 
         # Create a state that doesn't contain InjectedState
         invalid_state = StepState(env_state=jnp.array(0.0), steps=0)
 
         with pytest.raises(ValueError, match="Could not find InjectedState"):
-            w.set_reset_state(invalid_state, invalid_state, jnp.array(0.0))
+            w.set_reset_state(
+                invalid_state,
+                invalid_state,
+                reset_info=info.update(obs=jnp.array(0.0)),
+            )
 
-    def test_reset_raises_on_partial_reset_state(self):
-        """Verify that reset raises when only one of reset_state/reset_obs is set."""
-        env = StepCounterEnv()
-        w = StateInjectionWrapper(env)
-        key = jax.random.key(0)
+    def test_full_reset_info_preserves_structure_and_inner_extras(self):
+        w = StateInjectionWrapper(EpisodeStatisticsWrapper(StepCounterEnv()))
+        state, info = w.init(jax.random.key(0))
+        state_structure = jax.tree.structure(state)
+        info_structure = jax.tree.structure(info)
 
-        # Create state with only reset_state set (not reset_obs)
-        state_with_only_reset_state = w.InjectedState(
-            inner_state=StepState(env_state=jnp.array(0.0), steps=0),
-            reset_state=StepState(env_state=jnp.array(42.0), steps=0),
-            reset_obs=None,
+        injected_inner = state.inner_state.replace(
+            inner_state=StepState(env_state=jnp.asarray(42.0), steps=0)
         )
+        injected_info = info.update(obs=jnp.asarray(42.0))
+        state = w.set_reset_state(state, injected_inner, reset_info=injected_info)
 
-        with pytest.raises(ValueError, match="must set both"):
-            w.reset(state_with_only_reset_state, key)
-
-        # Create state with only reset_obs set (not reset_state)
-        state_with_only_reset_obs = w.InjectedState(
-            inner_state=StepState(env_state=jnp.array(0.0), steps=0),
-            reset_state=None,
-            reset_obs=jnp.array(42.0),
-        )
-
-        with pytest.raises(ValueError, match="must set both"):
-            w.reset(state_with_only_reset_obs, key)
+        assert jax.tree.structure(state) == state_structure
+        reset_state, reset_info = w.reset(state=state, key=jax.random.key(1))
+        assert jax.tree.structure(reset_info) == info_structure
+        assert hasattr(reset_info, "stats")
+        assert jnp.allclose(reset_info.obs, 42.0)
+        assert jnp.allclose(reset_state.inner_state.inner_state.env_state, 42.0)
 
 
 # ============================================================================
@@ -198,7 +221,11 @@ class TestStateInjectionWithAutoReset:
         state, _ = w.init(key)
         reset_state = StepState(env_state=jnp.array(42.0), steps=0)
         reset_obs = jnp.array(42.0)
-        state = inner_w.set_reset_state(state, reset_state, reset_obs)
+        state = inner_w.set_reset_state(
+            state,
+            reset_state,
+            reset_info=_reset_info_with_obs(state, reset_obs),
+        )
 
         # Step until termination triggers auto-reset
         state, _ = w.step(state, jnp.array(0.1))
@@ -221,7 +248,11 @@ class TestStateInjectionWithAutoReset:
         # Set a custom reset state - just pass the outermost state
         custom_state = StepState(env_state=jnp.array(100.0), steps=0)
         custom_obs = jnp.array(100.0)
-        state = inner_w.set_reset_state(state, custom_state, custom_obs)
+        state = inner_w.set_reset_state(
+            state,
+            custom_state,
+            reset_info=_reset_info_with_obs(state, custom_obs),
+        )
 
         # Step to trigger termination → auto-reset
         state, info = w.step(state, jnp.array(0.1))
@@ -241,7 +272,11 @@ class TestStateInjectionWithAutoReset:
         state, _ = w.init(key)
         custom_state = StepState(env_state=jnp.array(50.0), steps=0)
         custom_obs = jnp.array(50.0)
-        state = inner_w.set_reset_state(state, custom_state, custom_obs)
+        state = inner_w.set_reset_state(
+            state,
+            custom_state,
+            reset_info=_reset_info_with_obs(state, custom_obs),
+        )
 
         # Trigger multiple auto-resets
         for _ in range(5):
@@ -271,7 +306,11 @@ class TestStateInjectionWithAutoReset:
 
             # Set the reset state for this outer iteration
             # User just passes the outermost state
-            state = inner_w.set_reset_state(state, task_state, task_obs)
+            state = inner_w.set_reset_state(
+                state,
+                task_state,
+                reset_info=_reset_info_with_obs(state, task_obs),
+            )
 
             # Inner loop with auto-resets
             for inner_step in range(4):  # More than terminate_after to trigger resets
@@ -318,7 +357,11 @@ class TestStateInjectionJITCompatibility:
         def run_with_state(k, reset_state, reset_obs):
             s, _ = w.init(k)
             # Set the reset state - just pass the outermost state
-            s = inner_w.set_reset_state(s, reset_state, reset_obs)
+            s = inner_w.set_reset_state(
+                s,
+                reset_state,
+                reset_info=_reset_info_with_obs(s, reset_obs),
+            )
             for _ in range(3):
                 s, info = w.step(s, jnp.array(0.1))
             return s, info
@@ -345,7 +388,11 @@ class TestStateInjectionJITCompatibility:
             task_obs = task_value
 
             # Set reset state for this task - pass outermost state
-            state = inner_w.set_reset_state(state, task_state, task_obs)
+            state = inner_w.set_reset_state(
+                state,
+                task_state,
+                reset_info=_reset_info_with_obs(state, task_obs),
+            )
 
             # Run inner loop
             for _ in range(3):

--- a/tests/wrappers/test_truncation_wrapper.py
+++ b/tests/wrappers/test_truncation_wrapper.py
@@ -77,6 +77,19 @@ def test_nonpositive_max_steps_are_rejected(max_steps):
         TruncationWrapper(StepCounterEnv(), max_steps=max_steps)
 
 
+def test_max_steps_can_be_traced_when_vmapping_environment_construction():
+    max_steps = jnp.asarray([2, 3], dtype=jnp.int32)
+
+    envs = jax.vmap(
+        lambda horizon: TruncationWrapper(
+            StepCounterEnv(),
+            max_steps=horizon,
+        )
+    )(max_steps)
+
+    assert jnp.array_equal(envs.max_steps, max_steps)
+
+
 def test_truncated_remains_true_after_threshold():
     env = StepCounterEnv()
     w = TruncationWrapper(env, max_steps=2)

--- a/tests/wrappers/test_truncation_wrapper.py
+++ b/tests/wrappers/test_truncation_wrapper.py
@@ -54,25 +54,27 @@ def test_preserves_other_info_fields():
     assert bool(jnp.asarray(info.truncated)) is True
 
 
-def test_reset_overrides_underlying_truncated_true():
+def test_reset_preserves_underlying_truncated_true():
     env = StepCounterEnv(reset_truncated=True)
     w = TruncationWrapper(env, max_steps=5)
     key = jax.random.key(0)
     state, info = w.init(key)
-    assert info.truncated is False
+    assert info.truncated is True
 
 
-@pytest.mark.parametrize("max_steps", [0, 1])
-def test_max_steps_edge_values(max_steps):
+def test_max_steps_one_truncates_first_step():
     env = StepCounterEnv()
-    w = TruncationWrapper(env, max_steps=max_steps)
+    w = TruncationWrapper(env, max_steps=1)
     key = jax.random.key(0)
     state, info = w.init(key)
-    # First step should truncate immediately when max_steps == 0
     state, info = w.step(state, jnp.asarray(0.0))
-    # After first step, steps == 1; wrapper truncates when steps >= max_steps
-    expected = 1 >= max_steps
-    assert bool(jnp.asarray(info.truncated)) == expected
+    assert bool(jnp.asarray(info.truncated)) is True
+
+
+@pytest.mark.parametrize("max_steps", [0, -1])
+def test_nonpositive_max_steps_are_rejected(max_steps):
+    with pytest.raises(ValueError, match="max_steps.*positive|greater than zero"):
+        TruncationWrapper(StepCounterEnv(), max_steps=max_steps)
 
 
 def test_truncated_remains_true_after_threshold():
@@ -91,14 +93,14 @@ def test_truncated_remains_true_after_threshold():
     assert bool(jnp.asarray(info.truncated)) is True
 
 
-def test_wrapper_overrides_underlying_truncated_on_step():
+def test_wrapper_ors_with_underlying_truncated_on_step():
     env = StepCounterEnv(step_truncated=True)
     w = TruncationWrapper(env, max_steps=10)
     key = jax.random.key(0)
     state, info = w.init(key)
-    # Underlying env sets truncated True, but steps < max_steps => wrapper should set False
+    # The local time limit must not erase an earlier underlying truncation.
     state, info = w.step(state, jnp.asarray(0.5))
-    assert bool(jnp.asarray(info.truncated)) is False
+    assert bool(jnp.asarray(info.truncated)) is True
 
 
 def test_steps_as_jax_scalar_array_behaves_correctly():

--- a/tests/wrappers/test_vmap_wrapper.py
+++ b/tests/wrappers/test_vmap_wrapper.py
@@ -124,9 +124,7 @@ def test_normalization_works_on_both_sides_of_vmap(batch_size):
     )
     independent_state, independent_info = independent.init(jax.random.key(42))
 
-    shared = ObservationNormalizationWrapper(
-        VmapWrapper(base, batch_size=batch_size)
-    )
+    shared = ObservationNormalizationWrapper(VmapWrapper(base, batch_size=batch_size))
     shared_state, shared_info = shared.init(jax.random.key(42))
 
     assert independent_info.obs.shape == shared_info.obs.shape == (batch_size, 3)

--- a/tests/wrappers/test_vmap_wrapper.py
+++ b/tests/wrappers/test_vmap_wrapper.py
@@ -111,38 +111,27 @@ def test_step_raises_on_action_shape_mismatch():
 
 
 # -----------------------------------------------------------------------------
-# Core: Composability with normalization and order equivalence
+# Core: Composability with shared normalization
 # -----------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("batch_size", [2, 5])
-def test_normalize_then_vmap_equals_vmap_then_normalize(batch_size):
+def test_normalization_works_on_both_sides_of_vmap(batch_size):
     base = VectorToyEnv(dim=3)
-    # Order A: normalize then vmap
-    a = VmapWrapper(
+    independent = VmapWrapper(
         ObservationNormalizationWrapper(base),
         batch_size=batch_size,
     )
-    # Order B: vmap then normalize
-    b = ObservationNormalizationWrapper(VmapWrapper(base, batch_size=batch_size))
-    key = jax.random.key(42)
-    s_a, i_a = a.init(key)
-    s_b, i_b = b.init(key)
-    # Both produce batched observations with same shape/dtype; numerical values
-    # may differ due to per-env vs aggregated RMV semantics
-    assert i_a.obs.shape == i_b.obs.shape == (batch_size, 3)
-    assert i_a.obs.dtype == i_b.obs.dtype
+    independent_state, independent_info = independent.init(jax.random.key(42))
 
-    # Check normalization statistics shapes:
-    # Order A (normalize then vmap): rmv_state is vmapped, so each env has its own stats
-    rmv_a = s_a.rmv_state
-    assert rmv_a.mean.shape == (batch_size, 3)
-    assert rmv_a.var.shape == (batch_size, 3)
+    shared = ObservationNormalizationWrapper(
+        VmapWrapper(base, batch_size=batch_size)
+    )
+    shared_state, shared_info = shared.init(jax.random.key(42))
 
-    # Order B (vmap then normalize): rmv_state is shared (unbatched)
-    rmv_b = s_b.rmv_state
-    assert rmv_b.mean.shape == (3,)
-    assert rmv_b.var.shape == (3,)
+    assert independent_info.obs.shape == shared_info.obs.shape == (batch_size, 3)
+    assert independent_state.rmv_state.mean.shape == (batch_size, 3)
+    assert shared_state.rmv_state.mean.shape == (3,)
 
 
 def test_nested_vmaps_equivalence_reset_and_step():

--- a/uv.lock
+++ b/uv.lock
@@ -1102,6 +1102,7 @@ adapters = [
     { name = "jumanji" },
     { name = "navix" },
     { name = "playground" },
+    { name = "requests" },
 ]
 brax = [
     { name = "brax" },
@@ -1111,6 +1112,7 @@ craftax = [
 ]
 jumanji = [
     { name = "jumanji" },
+    { name = "requests" },
 ]
 mujoco-playground = [
     { name = "playground" },
@@ -1128,6 +1130,7 @@ adapters = [
     { name = "kinetix-env" },
     { name = "navix" },
     { name = "playground" },
+    { name = "requests" },
 ]
 dev = [
     { name = "hypothesis" },
@@ -1157,6 +1160,8 @@ requires-dist = [
     { name = "navix", marker = "extra == 'navix'", specifier = ">=0.7.0" },
     { name = "playground", marker = "extra == 'adapters'", specifier = ">=0.1.0" },
     { name = "playground", marker = "extra == 'mujoco-playground'", specifier = ">=0.1.0" },
+    { name = "requests", marker = "extra == 'adapters'" },
+    { name = "requests", marker = "extra == 'jumanji'" },
 ]
 provides-extras = ["brax", "craftax", "jumanji", "mujoco-playground", "navix", "adapters"]
 
@@ -1169,6 +1174,7 @@ adapters = [
     { name = "kinetix-env", git = "https://github.com/FLAIROx/Kinetix.git?rev=df4de60cabd42dbd1c35fb5214fdc6728710e33d" },
     { name = "navix", specifier = ">=0.7.0" },
     { name = "playground", specifier = ">=0.1.0" },
+    { name = "requests" },
 ]
 dev = [
     { name = "hypothesis", specifier = ">=6.148.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -183,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -428,21 +437,19 @@ wheels = [
 
 [[package]]
 name = "craftax"
-version = "1.5.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "chex" },
     { name = "flax" },
-    { name = "gymnax" },
     { name = "imageio" },
     { name = "jax" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pygame" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/f1/367d9de11af4046c82697d6cc91e5c9d99b956d719514456be01b48457cf/craftax-1.5.0.tar.gz", hash = "sha256:a8deddea60167934c23723a83df882e07a683c0e3ec7fb3a3e0a6364543401a9", size = 291469, upload-time = "2025-07-07T02:39:57.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/12/41e2147064092c5eebf5aa516912c5ffe07e42a42e4500acd63e5fb0af1c/craftax-1.6.1.tar.gz", hash = "sha256:975e33a7bc8f2c67fece4049d392cec0bbc71d11d34f018494ca20c2b0ac3902", size = 293247, upload-time = "2026-06-20T14:40:14.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/0c/b7ef5a2d5a0e32a46b003bd48e20720c7eaf443ca7a971ad9cd325747369/craftax-1.5.0-py3-none-any.whl", hash = "sha256:96826abc7d1fcf5ffbdd022100a6815b38c2b9bd22eaf43932a2252d2d7304d8", size = 410088, upload-time = "2025-07-07T02:39:56.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/63/a54881a60fd75995c49d9d52b03e4f6d1abd652c563c3aaf51d0ad24132a/craftax-1.6.1-py3-none-any.whl", hash = "sha256:09c2a78870a68f4af45709de73c77cf5b6df9e754cefbe9f05a1b8fb66243959", size = 412033, upload-time = "2026-06-20T14:40:07.497Z" },
 ]
 
 [[package]]
@@ -483,6 +490,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -604,11 +620,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.3"
+version = "3.29.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -782,6 +798,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce6724bb7cb3d0543dcba17206dce909f94176e68220b8eafee72e9f92bcf542", size = 243522, upload-time = "2026-01-28T05:58:03.517Z" },
     { url = "https://files.pythonhosted.org/packages/cf/b9/b04c3aa0aad2870cfe799f32f8b59789c98e1816bbce9e83f4823c5b840b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win32.whl", hash = "sha256:fca724a21a372731edb290841edd28a9fb1ee490f833392752844ac807c0086a", size = 552682, upload-time = "2026-01-28T05:58:05.649Z" },
     { url = "https://files.pythonhosted.org/packages/bd/e1/6d6816b296a529ac9b897ad228b1e084eb1f92319e96371880eebdc874a6/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:823c0bd7770977d4b10e0ed0aef2f3682276b7c88b8b65cfc540afce5951392f", size = 559464, upload-time = "2026-01-28T05:58:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a8/d4dab8a58fc2e6981fc7a58c4e56ba9d777fb24931cec6a22152edbb3540/glfw-2.10.0-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:a0d1f29f206219cc291edfb6cace663a86da2470632551c998e3db82d48ea177", size = 105288, upload-time = "2026-03-10T17:21:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/68d35e001872a7705112418da236fa2418d4f2e5419f8b2837f9b81bb3da/glfw-2.10.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d28d6f3ef217e64e35dc6fd0a7acb4cec9bfe7cd14dd9b35a7228a87002de154", size = 102139, upload-time = "2026-03-10T17:21:21.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/ca5984081aaae07c9d371cb11dc4e4ff603510678ed9b73e58b6c351fe63/glfw-2.10.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f968b522bb6a0e04aaf4dcac30a476d7229308bb2bac406a60587debb5a61e29", size = 229998, upload-time = "2026-03-10T17:21:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c4/82ac75fdcfba2896da7a573c0fc7f8ceb8f77ead6866d500d06c32f1c464/glfw-2.10.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:68cf3752bdadb6f4bc0a876247c28c88c7251ac39f8af076ed938fdfd71e72dd", size = 241944, upload-time = "2026-03-10T17:21:26.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/9f691823cca5eb6a08f346bd0ff03b78032db9370b509a1e9c8976fb20a5/glfw-2.10.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44d98de5dbf8f727e0cb29f9b29d29528ea7570f2e6f42f8430a69df05f12b48", size = 231009, upload-time = "2026-03-10T17:21:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
 ]
 
 [[package]]
@@ -802,7 +826,7 @@ wheels = [
 [[package]]
 name = "gymnax"
 version = "0.0.9"
-source = { git = "https://github.com/RobertTLange/gymnax.git#18f2e7f3cffafc7042c76fdc538c83957418a9a9" }
+source = { git = "https://github.com/RobertTLange/gymnax.git?rev=18f2e7f3cffafc7042c76fdc538c83957418a9a9#18f2e7f3cffafc7042c76fdc538c83957418a9a9" }
 dependencies = [
     { name = "flax" },
     { name = "gymnasium" },
@@ -934,6 +958,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,10 +1089,34 @@ wheels = [
 
 [[package]]
 name = "jax-envelope"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },
+]
+
+[package.optional-dependencies]
+adapters = [
+    { name = "brax" },
+    { name = "craftax" },
+    { name = "jumanji" },
+    { name = "navix" },
+    { name = "playground" },
+]
+brax = [
+    { name = "brax" },
+]
+craftax = [
+    { name = "craftax" },
+]
+jumanji = [
+    { name = "jumanji" },
+]
+mujoco-playground = [
+    { name = "playground" },
+]
+navix = [
+    { name = "navix" },
 ]
 
 [package.dev-dependencies]
@@ -1074,30 +1131,55 @@ adapters = [
 ]
 dev = [
     { name = "hypothesis" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
+]
+gymnax-adapter = [
+    { name = "gymnax" },
+]
+kinetix-adapter = [
+    { name = "kinetix-env" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "jax", specifier = ">=0.5.0" }]
+requires-dist = [
+    { name = "brax", marker = "extra == 'adapters'", specifier = ">=0.13.0" },
+    { name = "brax", marker = "extra == 'brax'", specifier = ">=0.13.0" },
+    { name = "craftax", marker = "extra == 'adapters'", specifier = ">=1.6.0" },
+    { name = "craftax", marker = "extra == 'craftax'", specifier = ">=1.6.0" },
+    { name = "jax", specifier = ">=0.5.0" },
+    { name = "jumanji", marker = "extra == 'adapters'", specifier = ">=1.0.1" },
+    { name = "jumanji", marker = "extra == 'jumanji'", specifier = ">=1.0.1" },
+    { name = "navix", marker = "extra == 'adapters'", specifier = ">=0.7.0" },
+    { name = "navix", marker = "extra == 'navix'", specifier = ">=0.7.0" },
+    { name = "playground", marker = "extra == 'adapters'", specifier = ">=0.1.0" },
+    { name = "playground", marker = "extra == 'mujoco-playground'", specifier = ">=0.1.0" },
+]
+provides-extras = ["brax", "craftax", "jumanji", "mujoco-playground", "navix", "adapters"]
 
 [package.metadata.requires-dev]
 adapters = [
     { name = "brax", specifier = ">=0.13.0" },
-    { name = "craftax", specifier = ">=1.4.3" },
-    { name = "gymnax", git = "https://github.com/RobertTLange/gymnax.git" },
+    { name = "craftax", specifier = ">=1.6.0" },
+    { name = "gymnax", git = "https://github.com/RobertTLange/gymnax.git?rev=18f2e7f3cffafc7042c76fdc538c83957418a9a9" },
     { name = "jumanji", specifier = ">=1.0.1" },
-    { name = "kinetix-env", git = "https://github.com/FLAIROx/Kinetix.git" },
+    { name = "kinetix-env", git = "https://github.com/FLAIROx/Kinetix.git?rev=df4de60cabd42dbd1c35fb5214fdc6728710e33d" },
     { name = "navix", specifier = ">=0.7.0" },
     { name = "playground", specifier = ">=0.1.0" },
 ]
 dev = [
     { name = "hypothesis", specifier = ">=6.148.1" },
+    { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.2" },
+    { name = "ty", specifier = ">=0.0.59" },
 ]
+gymnax-adapter = [{ name = "gymnax", git = "https://github.com/RobertTLange/gymnax.git?rev=18f2e7f3cffafc7042c76fdc538c83957418a9a9" }]
+kinetix-adapter = [{ name = "kinetix-env", git = "https://github.com/FLAIROx/Kinetix.git?rev=df4de60cabd42dbd1c35fb5214fdc6728710e33d" }]
 
 [[package]]
 name = "jax-tqdm"
@@ -1247,7 +1329,7 @@ wheels = [
 [[package]]
 name = "kinetix-env"
 version = "2.0.4"
-source = { git = "https://github.com/FLAIROx/Kinetix.git#df4de60cabd42dbd1c35fb5214fdc6728710e33d" }
+source = { git = "https://github.com/FLAIROx/Kinetix.git?rev=df4de60cabd42dbd1c35fb5214fdc6728710e33d#df4de60cabd42dbd1c35fb5214fdc6728710e33d" }
 dependencies = [
     { name = "argparse" },
     { name = "chex" },
@@ -1802,6 +1884,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2150,6 +2241,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
 name = "proglog"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2460,6 +2567,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2748,6 +2868,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shtab"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/b3/b7c99318ba2b0d7d7e71b78318c162690dd5639cd06e2d3bca9292737e4e/shtab-1.8.1.tar.gz", hash = "sha256:3edaf857ba164a0d7bb64e958eab8d6756d5aee3949c7f36a7e779bf1ce3b897", size = 46449, upload-time = "2026-07-03T11:43:26.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/2f/35d4ec80d8ee39e792cd6e0d4f3dd84ea6783f13b7c47b4c319d9062aaf0/shtab-1.8.1-py3-none-any.whl", hash = "sha256:4fc418e0173e66385e4605044a26a4910e73dde2dc23e809acc2f0275e842426", size = 14905, upload-time = "2026-07-03T11:43:25.374Z" },
+]
+
+[[package]]
 name = "simplejson"
 version = "3.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2949,6 +3078,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.59"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
+]
+
+[[package]]
 name = "typeguard"
 version = "4.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3009,16 +3163,19 @@ wheels = [
 
 [[package]]
 name = "tyro"
-version = "1.0.5"
+version = "0.9.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "shtab" },
     { name = "typeguard" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/34/1e306bacd2917f694fef5aa21ccd9d39dfa6747ddbe7a0f5c9612c734259/tyro-1.0.5.tar.gz", hash = "sha256:5b28c23cc8e844f284286b1043d06be0e62f7acff6f2b1b5b5db75466c6802fc", size = 453403, upload-time = "2026-01-13T20:50:51.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/40/7a84e7652f75526b31f45c2565b5db9e9e21d37201fd44bc341ea90edc53/tyro-0.9.35.tar.gz", hash = "sha256:e38dd3528ae6f8fc74e21c7e21ac412d22d237739758d521f470e7a20eb46e92", size = 325648, upload-time = "2025-10-13T08:55:57.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/86/eef272685bc6c15a8f79178aa8c6e07d956f0f91d97fab5a4d8af707b21b/tyro-1.0.5-py3-none-any.whl", hash = "sha256:87fcba42a1136cdabef8776a456bb4a05c0d52b81ccc2529e65c75da059ff3cd", size = 181241, upload-time = "2026-01-13T20:50:49.597Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/943b35b1a139a602a730e56592a3639bf796a87c91eebcd40cc51043ee5b/tyro-0.9.35-py3-none-any.whl", hash = "sha256:82d656389d3041c04dd68542f8ba9b77baf91a4aaaa627cd5c88af3b3dc6a2cd", size = 132641, upload-time = "2025-10-13T08:55:56.54Z" },
 ]
 
 [[package]]
@@ -3037,6 +3194,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Introduce the core `envelope` package with typed environment, space, struct, and wrapper abstractions.
- Add adapter integrations for Brax, Craftax, Gymnax, Jumanji, Kinetix, MuJoCo Playground, and Navix.
- Expand wrapper support for flattening, normalization, autoreset, vectorization, truncation, statistics, and state injection.
- Refresh docs, release notes, packaging metadata, and CI/publish workflows for the 0.5 release.
- Add broad coverage across adapters, spaces, structs, environment behavior, and wrapper contracts.

## Testing
- Added and updated unit and integration tests across adapters, spaces, environment primitives, and wrappers.
- Validation is covered by the expanded test suite and release workflow updates; no separate manual run was requested.