### PR TITLE
Add installed environment registry

### DIFF
--- a/docs/api/adapters.md
+++ b/docs/api/adapters.md
@@ -29,7 +29,7 @@ Most adapters expose extra suite data under `info.backend`, for example as
 placeholders and `info.backend.valid` is false. Navix retains its established top-level
 extra fields.
 
-## API Reference (`create`)
+## API Reference (`create`)
 
 ::: envelope.adapters.create
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -1,0 +1,71 @@
+# Environment registry
+
+Envelope keeps a global registry of environments, organized into suites. Its main
+purpose is to make available suites and environments discoverable through
+`registered_suites()` and `registered_environments()`. Envelope's built-in adapters
+are registered by default.
+
+An installed package can add a suite to `envelope.create` with an entry point in the
+`envelope.environments` group. The entry-point name becomes the suite prefix, and its
+target is a callable with the same arguments as `from_name`. Calling
+`envelope.create("suite_name::environment_name", env_kwargs=..., **kwargs)` passes the
+local ID `"environment_name"`, `env_kwargs`, and `kwargs` to that callable.
+
+A classmethod on an `Environment` subclass can optionally expose the environments it
+knows about:
+
+```toml
+[project.entry-points."envelope.environments"]
+suite_name = "package_name:EnvironmentClass.from_name"
+```
+
+```python
+from envelope import Environment
+
+
+class EnvironmentClass(Environment):
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs) -> Environment:
+        # Construct and return an Envelope Environment.
+        ...
+
+    @classmethod
+    def registered_names(cls):
+        # Return local IDs; Envelope adds the suite prefix.
+        return ("environment_a", "environment_b")
+```
+
+A plain function is also valid, but does not enumerate environment names:
+
+```toml
+[project.entry-points."envelope.environments"]
+suite_name = "package_name:create_environment"
+```
+
+```python
+def create_environment(env_name, env_kwargs=None, **kwargs) -> Environment:
+    # Construct and return an Envelope Environment.
+    ...
+```
+
+The registry API returns sorted tuples:
+
+```python
+import envelope
+
+envelope.registered_suites()
+envelope.registered_environments("suite_name")
+# ("suite_name::environment_a", "suite_name::environment_b")
+```
+
+Environment enumeration is best effort. A suite can still support `create` when it
+cannot list names or does not implement `registered_names`. Built-in suites take
+precedence over entry points with the same name. If multiple installed packages claim
+the same otherwise-unknown suite, creation fails; enumeration warns and returns an
+empty tuple.
+
+## API Reference
+
+::: envelope.registry.registered_suites
+
+::: envelope.registry.registered_environments

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,4 +43,5 @@ print(info)  # InfoContainer(obs=Array(...), reward=0.0, terminated=False, ...)
 - **[Spaces](api/spaces.md)**: observation and action space definitions.
 - **[Wrappers](api/wrappers.md)**: composable wrappers and how to order them.
 - **[Adapters](api/adapters.md)**: creating environments from third-party suites.
+- **[Registry](api/registry.md)**: exposing environments from installed packages.
 - **[Struct](api/struct.md)**: JAX pytree datastructures used throughout envelope.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,4 +69,5 @@ nav:
   - Spaces: api/spaces.md
   - Wrappers: api/wrappers.md
   - Adapters: api/adapters.md
+  - Registry: api/registry.md
   - Struct: api/struct.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jax-envelope"
-version = "0.5.0"
+version = "0.6.0"
 description = "A JAX-native environment interface with powerful wrappers and adapters for popular RL environment suites"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/envelope/__init__.py
+++ b/src/envelope/__init__.py
@@ -1,5 +1,6 @@
 from envelope.adapters import create
 from envelope.environment import Environment, InfoContainer
+from envelope.registry import registered_environments, registered_suites
 from envelope.spaces import BatchedSpace, Continuous, Discrete, PyTreeSpace, Space
 from envelope.struct import Container, FrozenPyTreeNode, field, static_field
 from envelope.typing import Array, Info, Key, PyTree, State
@@ -23,6 +24,8 @@ from envelope.wrappers import (
 __all__ = [
     # Basic functionality
     "create",
+    "registered_suites",
+    "registered_environments",
     "Environment",
     "Info",
     "InfoContainer",

--- a/src/envelope/adapters/__init__.py
+++ b/src/envelope/adapters/__init__.py
@@ -3,20 +3,7 @@
 from typing import Any, Literal, Protocol
 
 from envelope.environment import Environment
-
-# Lazy imports to avoid requiring all dependencies at once
-_env_module_map = {
-    "gymnax": ("envelope.adapters.gymnax_envelope", "GymnaxEnvelope"),
-    "brax": ("envelope.adapters.brax_envelope", "BraxEnvelope"),
-    "navix": ("envelope.adapters.navix_envelope", "NavixEnvelope"),
-    "jumanji": ("envelope.adapters.jumanji_envelope", "JumanjiEnvelope"),
-    "kinetix": ("envelope.adapters.kinetix_envelope", "KinetixEnvelope"),
-    "craftax": ("envelope.adapters.craftax_envelope", "CraftaxEnvelope"),
-    "mujoco_playground": (
-        "envelope.adapters.mujoco_playground_envelope",
-        "MujocoPlaygroundEnvelope",
-    ),
-}
+from envelope.registry import _load_factory
 
 
 class HasFromNameInit(Protocol):
@@ -76,27 +63,13 @@ def create(
             f"Environment ID must be in format 'suite::env_name', got: {original_env_id}"
         )
 
-    if suite not in _env_module_map:
-        raise ValueError(
-            f"Unknown environment suite: {suite}. "
-            f"Available suites: {list(_env_module_map.keys())}"
+    factory = _load_factory(suite)
+    env = factory(env_name, env_kwargs=env_kwargs, **kwargs)
+    if not isinstance(env, Environment):
+        raise TypeError(
+            f"Environment provider for suite '{suite}' returned "
+            f"{type(env).__name__}, not an Environment"
         )
-
-    # Lazy import the wrapper class
-    module_name, class_name = _env_module_map[suite]
-    try:
-        import importlib
-
-        module = importlib.import_module(module_name)
-        env_class: HasFromNameInit = getattr(module, class_name)
-    except ImportError as e:
-        raise ImportError(
-            f"Failed to import {suite} wrapper. "
-            f"Make sure the '{suite}' library is installed. "
-            f"Original error: {e}"
-        ) from e
-
-    env = env_class.from_name(env_name, env_kwargs=env_kwargs, **kwargs)
 
     if max_episode_steps == "default":
         max_episode_steps = env.default_max_steps

--- a/src/envelope/adapters/brax_envelope.py
+++ b/src/envelope/adapters/brax_envelope.py
@@ -3,6 +3,7 @@ from copy import copy
 from functools import cached_property
 from typing import Any, cast, override
 
+import brax.envs as brax_envs
 from brax.envs import Env as BraxEnv
 from brax.envs import create as brax_create
 from jax import numpy as jnp
@@ -48,6 +49,10 @@ class BraxEnvelope(Environment):
 
     brax_env: BraxEnv = static_field(unsafe=True)
     _max_steps: int | None = static_field(default=_BRAX_DEFAULT_EPISODE_LENGTH)
+
+    @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        return tuple(brax_envs._envs)
 
     @classmethod
     def from_name(

--- a/src/envelope/adapters/craftax_envelope.py
+++ b/src/envelope/adapters/craftax_envelope.py
@@ -83,6 +83,15 @@ class CraftaxEnvelope(Environment):
     _empty_backend_info: Container = field()
 
     @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        return (
+            "Craftax-Symbolic-v1",
+            "Craftax-Pixels-v1",
+            "Craftax-Classic-Symbolic-v1",
+            "Craftax-Classic-Pixels-v1",
+        )
+
+    @classmethod
     def from_name(
         cls,
         env_name: str,

--- a/src/envelope/adapters/gymnax_envelope.py
+++ b/src/envelope/adapters/gymnax_envelope.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, cast, override
 import jax
 import jax.numpy as jnp
 from gymnax import make as gymnax_create
+from gymnax import registered_envs
 from gymnax.environments import spaces as gymnax_spaces
 from gymnax.environments.environment import Environment as GymnaxEnv
 from gymnax.environments.environment import EnvParams as GymnaxEnvParams
@@ -54,6 +55,10 @@ class GymnaxEnvelope(Environment):
     env_params: PyTree = field()
     _max_steps: int | None = static_field()
     _empty_backend_info: Container = field()
+
+    @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        return tuple(registered_envs)
 
     @classmethod
     def from_name(

--- a/src/envelope/adapters/jumanji_envelope.py
+++ b/src/envelope/adapters/jumanji_envelope.py
@@ -7,6 +7,7 @@ import jax
 import jax.numpy as jnp
 from jumanji.env import Environment as JumanjiEnv
 from jumanji.registration import make as jumanji_make
+from jumanji.registration import registered_environments
 from jumanji.specs import Array, BoundedArray, DiscreteArray, MultiDiscreteArray, Spec
 from jumanji.types import TimeStep as JumanjiTimeStep
 
@@ -37,6 +38,10 @@ class JumanjiEnvelope(Environment):
 
     jumanji_env: JumanjiEnv = static_field(unsafe=True)
     _default_time_limit: int | None = static_field(default=None)
+
+    @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        return tuple(registered_environments())
 
     @classmethod
     def from_name(

--- a/src/envelope/adapters/kinetix_envelope.py
+++ b/src/envelope/adapters/kinetix_envelope.py
@@ -104,6 +104,14 @@ class KinetixEnvelope(Environment):
     _max_steps: int | None = static_field()
     _empty_backend_info: Container = field()
 
+    @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        levels = tuple(
+            path.relative_to(BASE_DIR).with_suffix("").as_posix()
+            for path in sorted(Path(BASE_DIR).glob("*/*.json"))
+        )
+        return ("s", "m", "l", "random", *levels)
+
     @property
     def default_max_steps(self) -> int | None:
         return self._max_steps

--- a/src/envelope/adapters/mujoco_playground_envelope.py
+++ b/src/envelope/adapters/mujoco_playground_envelope.py
@@ -48,6 +48,10 @@ class MujocoPlaygroundEnvelope(Environment):
     _default_max_steps: int | None = static_field(default=None)
 
     @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        return tuple(registry.ALL_ENVS)
+
+    @classmethod
     def from_name(
         cls,
         env_name: str,

--- a/src/envelope/adapters/navix_envelope.py
+++ b/src/envelope/adapters/navix_envelope.py
@@ -34,6 +34,10 @@ class NavixEnvelope(Environment):
     _max_steps: int | None = static_field(default=None)
 
     @classmethod
+    def registered_names(cls) -> tuple[str, ...]:
+        return tuple(navix.registry())
+
+    @classmethod
     def from_name(
         cls, env_name: str, env_kwargs: dict[str, Any] | None = None
     ) -> "NavixEnvelope":

--- a/src/envelope/registry.py
+++ b/src/envelope/registry.py
@@ -1,0 +1,123 @@
+"""Discovery of installed environment suites."""
+
+import importlib.metadata
+import warnings
+from collections.abc import Callable
+
+from envelope.environment import Environment
+
+_ENTRY_POINT_GROUP = "envelope.environments"
+
+_builtin_factories = {
+    "gymnax": "envelope.adapters.gymnax_envelope:GymnaxEnvelope.from_name",
+    "brax": "envelope.adapters.brax_envelope:BraxEnvelope.from_name",
+    "navix": "envelope.adapters.navix_envelope:NavixEnvelope.from_name",
+    "jumanji": "envelope.adapters.jumanji_envelope:JumanjiEnvelope.from_name",
+    "kinetix": "envelope.adapters.kinetix_envelope:KinetixEnvelope.from_name",
+    "craftax": "envelope.adapters.craftax_envelope:CraftaxEnvelope.from_name",
+    "mujoco_playground": (
+        "envelope.adapters.mujoco_playground_envelope:"
+        "MujocoPlaygroundEnvelope.from_name"
+    ),
+}
+
+
+def _entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
+    return tuple(importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP))
+
+
+def registered_suites() -> tuple[str, ...]:
+    """Return the names of built-in and installed environment suites."""
+    suites = _builtin_factories.keys() | {entry.name for entry in _entry_points()}
+    return tuple(sorted(suites))
+
+
+def _entry_point(suite: str) -> importlib.metadata.EntryPoint:
+    if suite in _builtin_factories:
+        return importlib.metadata.EntryPoint(
+            name=suite,
+            value=_builtin_factories[suite],
+            group=_ENTRY_POINT_GROUP,
+        )
+
+    matches = [entry for entry in _entry_points() if entry.name == suite]
+    if not matches:
+        raise ValueError(
+            f"Unknown environment suite: {suite}. "
+            f"Available suites: {list(registered_suites())}"
+        )
+    if len(matches) > 1:
+        providers = ", ".join(sorted(entry.value for entry in matches))
+        raise ValueError(
+            f"Multiple environment providers are registered for suite "
+            f"'{suite}': {providers}"
+        )
+    return matches[0]
+
+
+def _load_factory(suite: str) -> Callable[..., Environment]:
+    entry = _entry_point(suite)
+    try:
+        factory = entry.load()
+    except Exception as error:
+        raise ImportError(
+            f"Failed to load environment provider for suite '{suite}': {error}"
+        ) from error
+
+    if isinstance(factory, type) or not callable(factory):
+        raise TypeError(
+            f"Environment provider for suite '{suite}' must be a factory callable, "
+            f"got {factory!r}"
+        )
+
+    owner = getattr(factory, "__self__", None)
+    if isinstance(owner, type) and not issubclass(owner, Environment):
+        raise TypeError(
+            f"Environment provider for suite '{suite}' is bound to "
+            f"{owner.__name__}, which is not an Environment subclass"
+        )
+
+    return factory
+
+
+def registered_environments(suite: str) -> tuple[str, ...]:
+    """Return the environment IDs advertised by an installed suite."""
+    if suite not in registered_suites():
+        _entry_point(suite)
+
+    try:
+        factory = _load_factory(suite)
+        owner = getattr(factory, "__self__", None)
+        if not isinstance(owner, type):
+            return ()
+
+        registered_names = getattr(owner, "registered_names", None)
+        if registered_names is None:
+            return ()
+        if not callable(registered_names):
+            raise TypeError("registered_names must be callable")
+
+        names = registered_names()
+        if isinstance(names, str):
+            raise TypeError("registered_names must return an iterable of strings")
+        names = tuple(names)
+        if any(not isinstance(name, str) or not name for name in names):
+            raise TypeError("registered_names must return non-empty strings")
+    except Exception as error:
+        if (
+            suite in _builtin_factories
+            and isinstance(error, ImportError)
+            and isinstance(error.__cause__, ImportError)
+        ):
+            return ()
+        warnings.warn(
+            f"Could not list environments for suite '{suite}': {error}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return ()
+
+    return tuple(f"{suite}::{name}" for name in sorted(set(names)))
+
+
+__all__ = ["registered_environments", "registered_suites"]

--- a/tests/adapters/test_create.py
+++ b/tests/adapters/test_create.py
@@ -2,12 +2,13 @@
 
 These tests are dependency-free (no brax/gymnax/navix imports) and focus on:
 - parsing/validation of the env id
-- suite dispatch via the module map
-- lazy importing via importlib.import_module
+- suite dispatch via the registry
+- lazy importing via entry-point targets
 - argument forwarding and error wrapping
 """
 
 import importlib
+import importlib.metadata
 import inspect
 import types
 from functools import cached_property
@@ -17,7 +18,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-import envelope.adapters as adapters
+import envelope.registry as registry
 from envelope.adapters import create
 from envelope.environment import Environment, InfoContainer
 from envelope.spaces import Discrete
@@ -75,11 +76,13 @@ def _install_dummy_suite(
     class_name: str = "DummyWrapper",
     return_value: object | None = None,
 ):
-    """Patch the module map and import mechanism to a dummy wrapper."""
+    """Patch the built-in registry and import mechanism to a dummy wrapper."""
     import_calls: list[str] = []
     from_name_calls: list[dict[str, object]] = []
+    if return_value is None:
+        return_value = _FakeAdapter()
 
-    class DummyWrapper:
+    class DummyWrapper(_FakeAdapter):
         @classmethod
         def from_name(cls, env_name: str, env_kwargs=None, **kwargs):
             from_name_calls.append(
@@ -88,7 +91,7 @@ def _install_dummy_suite(
             return return_value
 
     dummy_module = types.SimpleNamespace(**{class_name: DummyWrapper})
-    real_import_module = importlib.import_module
+    real_import_module = importlib.metadata.import_module
 
     def fake_import_module(name: str):
         if name == module_name:
@@ -96,8 +99,12 @@ def _install_dummy_suite(
             return dummy_module
         return real_import_module(name)
 
-    monkeypatch.setattr(adapters, "_env_module_map", {suite: (module_name, class_name)})
-    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(
+        registry,
+        "_builtin_factories",
+        {suite: f"{module_name}:{class_name}.from_name"},
+    )
+    monkeypatch.setattr(importlib.metadata, "import_module", fake_import_module)
 
     return import_calls, from_name_calls
 
@@ -129,7 +136,9 @@ def test_create_unknown_suite_mentions_available_suites(
 ):
     # Keep the map deterministic so we can assert it appears in the message.
     monkeypatch.setattr(
-        adapters, "_env_module_map", {"dummy": ("dummy_mod", "DummyWrapper")}
+        registry,
+        "_builtin_factories",
+        {"dummy": "dummy_mod:DummyWrapper.from_name"},
     )
 
     with pytest.raises(ValueError) as excinfo:
@@ -143,20 +152,22 @@ def test_create_unknown_suite_mentions_available_suites(
 
 def test_create_wraps_import_error_and_chains_cause(monkeypatch):
     monkeypatch.setattr(
-        adapters, "_env_module_map", {"dummy": ("dummy_mod", "DummyWrapper")}
+        registry,
+        "_builtin_factories",
+        {"dummy": "dummy_mod:DummyWrapper.from_name"},
     )
 
     def fake_import_module(name: str):
         raise ImportError("boom")
 
-    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(importlib.metadata, "import_module", fake_import_module)
 
     with pytest.raises(ImportError) as excinfo:
         create("dummy::Env")
 
     msg = str(excinfo.value)
-    assert "Failed to import dummy wrapper" in msg
-    assert "Make sure the 'dummy' library is installed" in msg
+    assert "Failed to load environment provider for suite 'dummy'" in msg
+    assert "boom" in msg
     assert excinfo.value.__cause__ is not None
     assert isinstance(excinfo.value.__cause__, ImportError)
 
@@ -215,7 +226,7 @@ def test_create_wraps_import_error_and_chains_cause(monkeypatch):
         ),
     ],
 )
-def test_create_import_error_includes_exact_install_command(
+def test_create_import_error_identifies_suite_and_chains_cause(
     monkeypatch,
     suite,
     module_name,
@@ -224,9 +235,9 @@ def test_create_import_error_includes_exact_install_command(
     dependency,
 ):
     monkeypatch.setattr(
-        adapters,
-        "_env_module_map",
-        {suite: (module_name, class_name)},
+        registry,
+        "_builtin_factories",
+        {suite: f"{module_name}:{class_name}.from_name"},
     )
 
     missing = ModuleNotFoundError(f"No module named '{dependency}'", name=dependency)
@@ -235,28 +246,29 @@ def test_create_import_error_includes_exact_install_command(
         assert name == module_name
         raise missing
 
-    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(importlib.metadata, "import_module", fake_import_module)
 
     with pytest.raises(ImportError) as excinfo:
         create(f"{suite}::{env_name}")
 
     msg = str(excinfo.value)
-    assert f"Make sure the '{suite}' library is installed" in msg
+    assert f"Failed to load environment provider for suite '{suite}'" in msg
+    assert f"No module named '{dependency}'" in msg
     assert "pip install" not in msg
     assert "git+" not in msg
     assert excinfo.value.__cause__ is missing
 
 
 def test_create_forwards_env_name_env_kwargs_and_kwargs(monkeypatch):
-    sentinel = object()
+    adapter = _FakeAdapter()
     import_calls, from_name_calls = _install_dummy_suite(
-        monkeypatch, return_value=sentinel
+        monkeypatch, return_value=adapter
     )
 
     env_kwargs = {"a": 1}
     out = create("dummy::MyEnv", env_kwargs=env_kwargs, max_episode_steps=None, foo=2)
 
-    assert out is sentinel
+    assert out is adapter
     assert import_calls == ["dummy_mod"]
     assert from_name_calls == [
         {"env_name": "MyEnv", "env_kwargs": env_kwargs, "kwargs": {"foo": 2}}
@@ -265,7 +277,7 @@ def test_create_forwards_env_name_env_kwargs_and_kwargs(monkeypatch):
 
 def test_create_preserves_env_kwargs_none_vs_empty_dict(monkeypatch):
     _import_calls, from_name_calls = _install_dummy_suite(
-        monkeypatch, return_value=None
+        monkeypatch, return_value=_FakeAdapter()
     )
 
     create("dummy::A", max_episode_steps=None)
@@ -277,37 +289,37 @@ def test_create_preserves_env_kwargs_none_vs_empty_dict(monkeypatch):
 
 
 def test_create_passes_caller_env_kwargs_directly(monkeypatch):
-    sentinel = object()
+    adapter = _FakeAdapter()
     received: list[dict[str, object]] = []
 
-    class MutatingWrapper:
+    class MutatingWrapper(_FakeAdapter):
         @classmethod
         def from_name(cls, env_name: str, env_kwargs=None, **kwargs):
             del env_name, kwargs
             assert env_kwargs is not None
             received.append(env_kwargs)
             env_kwargs["adapter_internal"] = True
-            return sentinel
+            return adapter
 
     module = types.SimpleNamespace(MutatingWrapper=MutatingWrapper)
     monkeypatch.setattr(
-        adapters,
-        "_env_module_map",
-        {"dummy": ("dummy_mod", "MutatingWrapper")},
+        registry,
+        "_builtin_factories",
+        {"dummy": "dummy_mod:MutatingWrapper.from_name"},
     )
-    monkeypatch.setattr(importlib, "import_module", lambda _: module)
+    monkeypatch.setattr(importlib.metadata, "import_module", lambda _: module)
 
     env_kwargs: dict[str, object] = {"user_value": 3}
     out = create("dummy::Env", env_kwargs=env_kwargs, max_episode_steps=None)
 
-    assert out is sentinel
+    assert out is adapter
     assert received[0] is env_kwargs
     assert received[0] == {"user_value": 3, "adapter_internal": True}
 
 
 def test_create_splits_only_on_first_separator(monkeypatch):
     _import_calls, from_name_calls = _install_dummy_suite(
-        monkeypatch, return_value=None
+        monkeypatch, return_value=_FakeAdapter()
     )
 
     create("dummy::::ant", max_episode_steps=None)
@@ -316,24 +328,29 @@ def test_create_splits_only_on_first_separator(monkeypatch):
 
 def test_create_imports_only_the_requested_suite(monkeypatch):
     import_calls: list[str] = []
+    adapter_a = _FakeAdapter()
+    adapter_b = _FakeAdapter()
 
-    class WrapperA:
+    class WrapperA(_FakeAdapter):
         @classmethod
         def from_name(cls, env_name: str, env_kwargs=None, **kwargs):
-            return "A"
+            return adapter_a
 
-    class WrapperB:
+    class WrapperB(_FakeAdapter):
         @classmethod
         def from_name(cls, env_name: str, env_kwargs=None, **kwargs):
-            return "B"
+            return adapter_b
 
     module_a = types.SimpleNamespace(WrapperA=WrapperA)
     module_b = types.SimpleNamespace(WrapperB=WrapperB)
 
     monkeypatch.setattr(
-        adapters,
-        "_env_module_map",
-        {"a": ("a_mod", "WrapperA"), "b": ("b_mod", "WrapperB")},
+        registry,
+        "_builtin_factories",
+        {
+            "a": "a_mod:WrapperA.from_name",
+            "b": "b_mod:WrapperB.from_name",
+        },
     )
 
     def fake_import_module(name: str):
@@ -344,10 +361,20 @@ def test_create_imports_only_the_requested_suite(monkeypatch):
             return module_b
         raise AssertionError(f"Unexpected import: {name}")
 
-    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(importlib.metadata, "import_module", fake_import_module)
 
-    assert create("a::Env", max_episode_steps=None) == "A"
+    assert create("a::Env", max_episode_steps=None) is adapter_a
     assert import_calls == ["a_mod"]
+
+
+def test_create_rejects_non_environment_factory_result(monkeypatch):
+    _install_dummy_suite(monkeypatch, return_value=object())
+
+    with pytest.raises(
+        TypeError,
+        match="Environment provider for suite 'dummy' returned object, not an Environment",
+    ):
+        create("dummy::Env", max_episode_steps=None)
 
 
 def test_create_wraps_with_truncation_when_default_max_steps_set(monkeypatch):

--- a/tests/adapters/test_registered_names.py
+++ b/tests/adapters/test_registered_names.py
@@ -1,0 +1,71 @@
+"""Adapter-local environment name enumeration tests."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adapters
+
+
+def test_brax_registered_names_match_upstream_registry():
+    brax_envs = pytest.importorskip("brax.envs")
+    from envelope.adapters.brax_envelope import BraxEnvelope
+
+    assert BraxEnvelope.registered_names() == tuple(brax_envs._envs)
+
+
+def test_gymnax_registered_names_match_upstream_registry():
+    gymnax = pytest.importorskip("gymnax")
+    from envelope.adapters.gymnax_envelope import GymnaxEnvelope
+
+    assert GymnaxEnvelope.registered_names() == tuple(gymnax.registered_envs)
+
+
+def test_jumanji_registered_names_match_upstream_registry():
+    jumanji = pytest.importorskip("jumanji")
+    from envelope.adapters.jumanji_envelope import JumanjiEnvelope
+
+    assert set(JumanjiEnvelope.registered_names()) == jumanji.registered_environments()
+
+
+def test_navix_registered_names_match_upstream_registry():
+    navix = pytest.importorskip("navix")
+    from envelope.adapters.navix_envelope import NavixEnvelope
+
+    assert NavixEnvelope.registered_names() == tuple(navix.registry())
+
+
+def test_mujoco_playground_registered_names_match_upstream_registry():
+    mujoco_playground = pytest.importorskip("mujoco_playground")
+    from envelope.adapters.mujoco_playground_envelope import MujocoPlaygroundEnvelope
+
+    assert MujocoPlaygroundEnvelope.registered_names() == tuple(
+        mujoco_playground.registry.ALL_ENVS
+    )
+
+
+def test_craftax_registered_names_are_canonical_ids():
+    pytest.importorskip("craftax")
+    from envelope.adapters.craftax_envelope import CraftaxEnvelope
+
+    assert CraftaxEnvelope.registered_names() == (
+        "Craftax-Symbolic-v1",
+        "Craftax-Pixels-v1",
+        "Craftax-Classic-Symbolic-v1",
+        "Craftax-Classic-Pixels-v1",
+    )
+
+
+def test_kinetix_registered_names_include_modes_and_packaged_levels():
+    saving = pytest.importorskip("kinetix.util.saving")
+    from envelope.adapters.kinetix_envelope import KinetixEnvelope
+
+    base_dir = Path(saving.BASE_DIR)
+    packaged_levels = {
+        path.relative_to(base_dir).with_suffix("").as_posix()
+        for path in base_dir.glob("*/*.json")
+    }
+    names = set(KinetixEnvelope.registered_names())
+
+    assert names == {"s", "m", "l", "random", *packaged_levels}
+    assert all(not name.endswith(".json") for name in names)

--- a/tests/adapters/test_registry.py
+++ b/tests/adapters/test_registry.py
@@ -1,0 +1,399 @@
+"""Tests for installed environment-suite discovery."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import sys
+import warnings
+from functools import cached_property
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+import envelope
+import envelope.registry as registry
+from envelope.adapters import create
+from envelope.environment import Environment
+from envelope.spaces import Discrete
+
+_PROVIDER_CALLS: list[tuple[str, dict[str, Any] | None, dict[str, Any]]] = []
+
+
+class _FakeEnvironment(Environment):
+    @cached_property
+    def observation_space(self) -> Discrete:
+        return Discrete(n=1)
+
+    @cached_property
+    def action_space(self) -> Discrete:
+        return Discrete(n=1)
+
+    def init(self, key):
+        raise NotImplementedError
+
+    def step(self, state, action):
+        raise NotImplementedError
+
+
+class _ClassmethodProvider(_FakeEnvironment):
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        _PROVIDER_CALLS.append((env_name, env_kwargs, kwargs))
+        return cls()
+
+    @classmethod
+    def registered_names(cls):
+        return (name for name in ("zeta", "alpha", "zeta", "nested::child"))
+
+
+class _NoCatalogueProvider(_FakeEnvironment):
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return cls()
+
+
+class _ForeignProvider:
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return _FakeEnvironment()
+
+
+class _NonCallableCatalogue(_FakeEnvironment):
+    registered_names: ClassVar[tuple[str, ...]] = ("one",)
+
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return cls()
+
+
+class _InvalidCatalogue(_FakeEnvironment):
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return cls()
+
+    @classmethod
+    def registered_names(cls):
+        return ("valid", "", 3)
+
+
+class _RaisingCatalogue(_FakeEnvironment):
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return cls()
+
+    @classmethod
+    def registered_names(cls):
+        raise RuntimeError("catalogue exploded")
+
+
+class _StringCatalogue(_FakeEnvironment):
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return cls()
+
+    @classmethod
+    def registered_names(cls):
+        return "not-a-catalogue"
+
+
+class _LiveCatalogue(_FakeEnvironment):
+    names: ClassVar[list[str]] = []
+
+    @classmethod
+    def from_name(cls, env_name, env_kwargs=None, **kwargs):
+        return cls()
+
+    @classmethod
+    def registered_names(cls):
+        return cls.names
+
+
+_NOT_CALLABLE = object()
+_FACTORY_ERROR = RuntimeError("factory exploded")
+
+
+def _plain_factory(env_name, env_kwargs=None, **kwargs):
+    _PROVIDER_CALLS.append((env_name, env_kwargs, kwargs))
+    return _FakeEnvironment()
+
+
+def _bad_return_factory(env_name, env_kwargs=None, **kwargs):
+    return object()
+
+
+def _raising_factory(env_name, env_kwargs=None, **kwargs):
+    raise _FACTORY_ERROR
+
+
+def _entry_point(name: str, target: str) -> importlib.metadata.EntryPoint:
+    return importlib.metadata.EntryPoint(
+        name=name,
+        value=f"{__name__}:{target}",
+        group="envelope.environments",
+    )
+
+
+def _set_providers(monkeypatch, *entry_points, builtins=None) -> None:
+    monkeypatch.setattr(registry, "_entry_points", lambda: tuple(entry_points))
+    if builtins is not None:
+        monkeypatch.setattr(registry, "_builtin_factories", builtins)
+
+
+def test_registered_suites_is_sorted_and_does_not_load_targets(monkeypatch):
+    missing_module = "envelope_registry_metadata_only_target"
+    entry_points = (
+        importlib.metadata.EntryPoint(
+            name="zeta",
+            value=f"{missing_module}:factory",
+            group="envelope.environments",
+        ),
+        importlib.metadata.EntryPoint(
+            name="alpha",
+            value=f"{missing_module}:other_factory",
+            group="envelope.environments",
+        ),
+        importlib.metadata.EntryPoint(
+            name="alpha",
+            value=f"{missing_module}:third_factory",
+            group="envelope.environments",
+        ),
+    )
+    _set_providers(monkeypatch, *entry_points, builtins={"middle": "unused"})
+
+    assert registry.registered_suites() == ("alpha", "middle", "zeta")
+    assert missing_module not in sys.modules
+
+
+def test_real_dist_info_is_discovered_before_its_module_is_imported(
+    tmp_path: Path, monkeypatch
+):
+    suite = "temporary_suite"
+    module_name = "temporary_envelope_provider"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(
+        f"""
+from {__name__} import _FakeEnvironment
+
+calls = []
+
+def create(env_name, env_kwargs=None, **kwargs):
+    calls.append((env_name, env_kwargs, kwargs))
+    return _FakeEnvironment()
+""".lstrip()
+    )
+    dist_info = tmp_path / "temporary_envelope_provider-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: temporary-envelope-provider\nVersion: 1.0\n"
+    )
+    (dist_info / "entry_points.txt").write_text(
+        f"[envelope.environments]\n{suite} = {module_name}:create\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+
+    assert module_name not in sys.modules
+    suites = envelope.registered_suites()
+    assert suites == tuple(sorted(suites))
+    assert suite in suites
+    assert module_name not in sys.modules
+
+    env_kwargs = {"difficulty": 2}
+    try:
+        env = envelope.create(
+            f"{suite}::walk",
+            env_kwargs=env_kwargs,
+            max_episode_steps=None,
+            render=False,
+        )
+        provider = sys.modules[module_name]
+        assert isinstance(env, _FakeEnvironment)
+        assert provider.calls == [("walk", env_kwargs, {"render": False})]
+        assert provider.calls[0][1] is env_kwargs
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_classmethod_provider_creates_and_lists_environments(monkeypatch):
+    _PROVIDER_CALLS.clear()
+    _set_providers(
+        monkeypatch, _entry_point("plugin", "_ClassmethodProvider.from_name")
+    )
+
+    env_kwargs = {"difficulty": 3}
+    env = create(
+        "plugin::walk", env_kwargs=env_kwargs, max_episode_steps=None, render=True
+    )
+
+    assert isinstance(env, _ClassmethodProvider)
+    assert _PROVIDER_CALLS == [("walk", env_kwargs, {"render": True})]
+    assert registry.registered_environments("plugin") == (
+        "plugin::alpha",
+        "plugin::nested::child",
+        "plugin::zeta",
+    )
+
+
+def test_plain_function_provider_creates_but_does_not_list(monkeypatch):
+    _PROVIDER_CALLS.clear()
+    _set_providers(monkeypatch, _entry_point("function", "_plain_factory"))
+
+    env = create("function::walk", max_episode_steps=None)
+
+    assert isinstance(env, _FakeEnvironment)
+    assert _PROVIDER_CALLS == [("walk", None, {})]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert registry.registered_environments("function") == ()
+
+
+def test_builtin_provider_takes_precedence_over_same_named_entry_point(monkeypatch):
+    _PROVIDER_CALLS.clear()
+    suite = "claimed"
+    _set_providers(
+        monkeypatch,
+        importlib.metadata.EntryPoint(
+            name=suite,
+            value="provider_that_must_not_be_loaded:factory",
+            group="envelope.environments",
+        ),
+        builtins={suite: f"{__name__}:_ClassmethodProvider.from_name"},
+    )
+
+    env = create(f"{suite}::walk", max_episode_steps=None)
+
+    assert isinstance(env, _ClassmethodProvider)
+    assert registry.registered_suites() == (suite,)
+    assert registry.registered_environments(suite)[0] == f"{suite}::alpha"
+
+
+def test_duplicate_external_providers_are_listed_once_but_cannot_create(
+    monkeypatch,
+):
+    suite = "duplicate"
+    _set_providers(
+        monkeypatch,
+        _entry_point(suite, "_plain_factory"),
+        _entry_point(suite, "_bad_return_factory"),
+        builtins={},
+    )
+
+    assert registry.registered_suites() == (suite,)
+    with pytest.raises(ValueError, match=suite) as excinfo:
+        create(f"{suite}::walk", max_episode_steps=None)
+    assert "_plain_factory" in str(excinfo.value)
+    assert "_bad_return_factory" in str(excinfo.value)
+
+    with pytest.warns(RuntimeWarning, match=suite):
+        assert registry.registered_environments(suite) == ()
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["_FakeEnvironment", "_NOT_CALLABLE", "_ForeignProvider.from_name"],
+)
+def test_create_rejects_invalid_provider_targets(monkeypatch, target):
+    suite = "invalid_target"
+    _set_providers(monkeypatch, _entry_point(suite, target), builtins={})
+
+    with pytest.raises(TypeError, match=suite):
+        create(f"{suite}::walk", max_episode_steps=None)
+
+
+def test_create_validates_provider_result(monkeypatch):
+    suite = "invalid_result"
+    _set_providers(monkeypatch, _entry_point(suite, "_bad_return_factory"))
+
+    with pytest.raises(TypeError, match=suite):
+        create(f"{suite}::walk", max_episode_steps=None)
+
+
+def test_provider_factory_exception_propagates_unchanged(monkeypatch):
+    suite = "raising_factory"
+    _set_providers(monkeypatch, _entry_point(suite, "_raising_factory"))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        create(f"{suite}::walk", max_episode_steps=None)
+
+    assert excinfo.value is _FACTORY_ERROR
+
+
+def test_unknown_suite_is_an_error_for_creation_and_listing(monkeypatch):
+    _set_providers(monkeypatch, builtins={})
+
+    with pytest.raises(ValueError, match="missing"):
+        create("missing::walk", max_episode_steps=None)
+    with pytest.raises(ValueError, match="missing"):
+        registry.registered_environments("missing")
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "_NonCallableCatalogue.from_name",
+        "_InvalidCatalogue.from_name",
+        "_RaisingCatalogue.from_name",
+        "_StringCatalogue.from_name",
+    ],
+)
+def test_malformed_external_catalogue_warns_and_returns_empty(monkeypatch, target):
+    suite = "bad_catalogue"
+    _set_providers(monkeypatch, _entry_point(suite, target), builtins={})
+
+    with pytest.warns(RuntimeWarning, match=suite):
+        assert registry.registered_environments(suite) == ()
+
+
+def test_environment_catalogue_is_read_again_on_each_call(monkeypatch):
+    suite = "live_catalogue"
+    monkeypatch.setattr(_LiveCatalogue, "names", ["first"])
+    _set_providers(
+        monkeypatch,
+        _entry_point(suite, "_LiveCatalogue.from_name"),
+        builtins={},
+    )
+
+    assert registry.registered_environments(suite) == (f"{suite}::first",)
+
+    _LiveCatalogue.names[:] = ["second"]
+    assert registry.registered_environments(suite) == (f"{suite}::second",)
+
+
+def test_external_load_failure_warns_and_returns_empty(monkeypatch):
+    suite = "broken_import"
+    entry_point = importlib.metadata.EntryPoint(
+        name=suite,
+        value="missing_envelope_provider_module:factory",
+        group="envelope.environments",
+    )
+    _set_providers(monkeypatch, entry_point, builtins={})
+
+    with pytest.warns(RuntimeWarning, match=suite):
+        assert registry.registered_environments(suite) == ()
+
+
+def test_unavailable_builtin_listing_is_silent(monkeypatch):
+    suite = "unavailable_builtin"
+    _set_providers(
+        monkeypatch,
+        builtins={suite: "missing_builtin_adapter:Adapter.from_name"},
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert registry.registered_environments(suite) == ()
+
+
+def test_bound_provider_without_catalogue_returns_empty_without_warning(monkeypatch):
+    suite = "no_catalogue"
+    _set_providers(
+        monkeypatch,
+        _entry_point(suite, "_NoCatalogueProvider.from_name"),
+        builtins={},
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert registry.registered_environments(suite) == ()

--- a/uv.lock
+++ b/uv.lock
@@ -1089,7 +1089,7 @@ wheels = [
 
 [[package]]
 name = "jax-envelope"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },


### PR DESCRIPTION
## Summary

- discover installed environment suites through the `envelope.environments` entry-point group
- add `registered_suites()` and `registered_environments()` with lazy built-in catalogues
- validate provider factories while preserving existing `create()` behavior
- document the provider contract and bump the package version to 0.6.0

## Motivation

Installed provider packages should work through `envelope.create()` without requiring users to import them first. The registry also gives users a simple way to inspect available suites and concrete environment IDs.

## Validation

- `uv run pytest -q` — 657 passed
- `uv run pytest tests/adapters/test_create.py tests/adapters/test_registry.py -q` — 62 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run ty check src/envelope`
- `uv lock --check`
- `uv run pytest tests/test_distribution_artifacts.py -q` — 1 passed
